### PR TITLE
Speed improvements

### DIFF
--- a/src/napari_convpaint/conv_paint.py
+++ b/src/napari_convpaint/conv_paint.py
@@ -825,11 +825,12 @@ class ConvPaintWidget(QWidget):
             save_file, _ = dialog.getOpenFileName(self, "Choose model", None, "JOBLIB (*.joblib)")
         save_file = Path(save_file)
         self.random_forest, self.param = load_trained_classifier(save_file)
-        self.reset_predict_buttons_after_training()
         self.current_model_path.setText(save_file.name)
 
         self.update_gui_from_params()
         self.model = Hookmodel(param=self.param, use_cuda=self.check_use_cuda.isChecked())
+
+        self.reset_predict_buttons_after_training()
 
 
     def update_gui_from_params(self):


### PR DESCRIPTION
This PR implements two major improvements in speed.

## Training
In order to gather data for training, initially features were generated using the entire picture and then annotated pixels were extracted from this large stack of filtered images. This is wasting both processing time and memory as most data are not used. In this PR, we first detect annotated regions, define bounding boxes around these regions and then process only this set of bounding boxes.

## Prediction
In a similar way for training, we need to create features for *all pixels* in the image. This means that we end up with stacks of tens or hundreds of filtered images. For very large images, this can go beyond space in RAM and be extremely slow. At prediction time we however don't need to process all pixels at the same time, and can proceed on image tiles. Once an image tile has been processed, the attached stack of filtered images can be discarded and we only keep the segmentation. Therefore here we only need to fit a single tile of filtered images. Additionally, stacks can be processed in parallel. The only complication is to avoid creating artefacts at tile boundaries. As we use convolutional filters that have boundary effects, we create overlapping tiles and only keep the region that is not affected at the edges (except for the true edges of course). An additional checkbox is added to the interface to enable tiling.