### PR TITLE
Suggestions_roman

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,11 +34,6 @@ the coverage at least stays the same before you submit a pull request.
 Distributed under the terms of the [BSD-3] license,
 "napari-convpaint" is free and open source software
 
-## Contributing
-
-Contributions are very welcome. Tests can be run with [tox], please ensure
-the coverage at least stays the same before you submit a pull request.
-
 # Authors
 
 The idea behind this napari plugin was first developed by Lucien Hinderling in the group of [Olivier Pertz](https://www.pertzlab.net/), at the Institute of Cell Biology, University of Bern. The code has first been shared as open source resource in form of a [Jupyter Notebook](https://github.com/hinderling/napari_pixel_classifier). With the desire to make this resource accessible to a broader public in the scientific community, the Pertz lab obtained a CZI napari plugin development grant with the title ["Democratizing Image Analysis with an Easy-to-Train Classifier"](https://chanzuckerberg.com/science/programs-resources/imaging/napari/democratizing-image-analysis-with-an-easy-to-train-classifier/) which supported the adaptation of the initial concept as a napari plugin called napari-convpaint. The plugin has been developed by Guillaume Witz, Mykhailo Vladymyrov and Ana Stojiljkovic at the [Data Science Lab](https://www.dsl.unibe.ch/), University of Bern, in tight collaboration with the Pertz lab.

--- a/src/napari_convpaint/conv_paint_utils.py
+++ b/src/napari_convpaint/conv_paint_utils.py
@@ -1169,20 +1169,22 @@ def get_features_all_samples_rich(model, images, annotations, scalings=[1],
 def train_classifier(features, targets):
     """Train a random forest classifier given a set of features and targets."""
 
-    # train model
-    # split train/test
-    X, X_test, y, y_test = train_test_split(features, targets,
-                                            test_size=0.2,
-                                            random_state=42)
+    # split train/test - not necessary, since we are training a random forest
+    # split_dataset = train_test_split(features, targets,
+    #                                  test_size=0.2,
+    #                                  random_state=42)
+    # features_train, features_test, labels_train, labels_test = split_dataset
+    # instead use all features for training
+    features_train, labels_train = features, targets
 
     # train a random forest classififer
     random_forest = RandomForestClassifier(n_estimators=100)
     #random_forest = RandomForestClassifier(n_estimators=100, n_jobs=8, max_depth=5)
     #import xgboost as xgb
     #random_forest = xgb.XGBClassifier(tree_method="hist", n_estimators=100, n_jobs=8)
-    #random_forest.fit(X, y-1)
+    #random_forest.fit(features_train, labels_train-1)
 
-    random_forest.fit(X, y)
+    random_forest.fit(features_train, labels_train)
 
     return random_forest
 


### PR DESCRIPTION
I added 3 suggested changes:
- Removing of the split into train/test features for training the random forest
- A cosmetic detail in the readme that I noticed
- A function to calculate the largest kernel size needed for a cnn hookmodel; including a suggestion on how to implement it in the existing code

### NOTES about padding and scaling

From experiences with DINOv2 (with its 14x14 patches) I suggest following procedure:
- pad image/labels on each side according to the max_kernel_size, use mode __"reflect"__ or similar
- use padded image for entire feature extraction etc.
- decide if shall use cropped annotations
    * if yes, "pad" annotated boxes of image/labels on each side according to the max_kernel_size for cropping (see suggestion in commit)
    * ensure to use the same approach to "pad" the boxes as used for padding the image (in my commit I simply add max_kernel_size//2 on each side); this is important to ensure that the box cannot be out of bound of the padded image, in case of an annotation on the edge
- crop final results back, removing the pads, after reshaping to size of padded image

__However__, the scalings need to be taken into account and the pad sizes adjusted. Or, instead it might even be easier to do the padding separate for the different scalings, in which case the same padding can be applied to each downscaled version...

Feel free to peak at the padding in my dino implementation under https://github.com/quasar1357/scribbles_creator/blob/main/dino_forest.py
Maybe the padding and re-cropping used in the functions train_dino_forest() and predict_dino_forest_single_img() could be of help
Note however, that the goal there is different. For DINOv2 we strictly want an image of multiple patch-sizes, while here we want to ensure each pixel has enough information around it.