### PR TITLE
Fix and adjust tiling

### DIFF
--- a/src/napari_convpaint/_tests/test_tiling.py
+++ b/src/napari_convpaint/_tests/test_tiling.py
@@ -85,6 +85,7 @@ def _assert_equal_segmentations(seg_a, seg_b, label_a, label_b):
         ("vgg-m", [1]),  # 3 layers, total_stride=2 — misalignment by 1 (odd tile)
         ("vgg-l", [1]),  # 5 layers, total_stride=4 — misalignment up to 3 (bigger hit)
         ("ilastik", [1]),  # ilastik filter set; FE-reported kernel_size=41 -> pad=20
+        ("gaussian", [1]),  # skimage.filters.gaussian, sigma=3; FE reports pad=2*sigma=6
     ],
 )
 @pytest.mark.parametrize("use_rf", [True, False], ids=["rf", "catboost"])

--- a/src/napari_convpaint/_tests/test_tiling.py
+++ b/src/napari_convpaint/_tests/test_tiling.py
@@ -84,6 +84,7 @@ def _assert_equal_segmentations(seg_a, seg_b, label_a, label_b):
     [
         ("vgg-m", [1]),  # 3 layers, total_stride=2 — misalignment by 1 (odd tile)
         ("vgg-l", [1]),  # 5 layers, total_stride=4 — misalignment up to 3 (bigger hit)
+        ("ilastik", [1]),  # ilastik filter set; FE-reported kernel_size=41 -> pad=20
     ],
 )
 @pytest.mark.parametrize("use_rf", [True, False], ids=["rf", "catboost"])

--- a/src/napari_convpaint/_tests/test_tiling.py
+++ b/src/napari_convpaint/_tests/test_tiling.py
@@ -198,3 +198,39 @@ def test_tile_annotations_textured_image_default_vgg(use_rf):
         seg(False), seg(True),
         'tile_annotations=False', 'tile_annotations=True',
     )
+
+
+# --------------------------------------------------------------------------- #
+# image_downsample × pipeline alignment: pins that train+segment succeed and  #
+# return original-shape output at each `image_downsample` value, including    #
+# odd factors that previously crashed get_features_targets (image/labels      #
+# shape drift before scale_img was made symmetric via pre-pad).               #
+# --------------------------------------------------------------------------- #
+
+@pytest.mark.parametrize("image_downsample", [-2, 0, 2, 3, 4])
+def test_train_and_segment_across_image_downsample(image_downsample):
+    """End-to-end train+segment at boundary `image_downsample` values. Verifies
+    (a) no crash through scale_img + _get_overall_paddings + FE + restore, and
+    (b) segmentation comes back at the original input shape.
+    """
+    rng = np.random.default_rng(0)
+    h = w = 256  # 256 % 3 = 1 → exercises the odd-factor pad path
+    im_2d = rng.standard_normal((h, w)).astype(np.float32)
+    im = np.stack([im_2d, im_2d, im_2d], axis=0)
+    annot = np.zeros((h, w), dtype=np.uint16)
+    annot[40:55, 40:55] = 1
+    annot[180:195, 180:195] = 2
+
+    cp = ConvpaintModel(alias='vgg')
+    cp.set_params(
+        tile_annotations=False, tile_image=False,
+        channel_mode='rgb', normalize=1,
+        image_downsample=image_downsample,
+    )
+    cp.train(im, annot, fe_use_device='cpu', use_rf=True)
+    seg = cp.segment(im, fe_use_device='cpu')
+
+    assert seg.shape[-2:] == (h, w), (
+        f"image_downsample={image_downsample}: expected segmentation shape "
+        f"to restore to ({h},{w}), got {seg.shape}"
+    )

--- a/src/napari_convpaint/_tests/test_tiling.py
+++ b/src/napari_convpaint/_tests/test_tiling.py
@@ -1,0 +1,198 @@
+"""Hypothesis: Tiling must not change the segmentation.
+
+The padding applied before tiling is derived from the feature extractor's
+receptive field (kernel size, conv depth / pooling) and binning (fe_scalings).
+With that padding AND alignment of tile dims to the FE's downsampling grid in
+place, feature values at annotated pixels match whether tiling is on or off —
+so, with a deterministic classifier trained on a canonical sample order,
+training produces the same model and segmentation is pixel-identical.
+
+These tests pin both tiling paths:
+
+1. `utils.tile_annot` — tiles must be aligned to `patch_size * total_stride *
+   lcm(fe_scalings)`. Deeper feature maps are at coarser resolution (e.g. 1/2
+   for VGG-m, 1/4 for VGG-l); if the tile dim is not a multiple of that, the
+   upsample ratio differs from the whole-padded-image case and align_corners=
+   False samples the feature map at shifted sub-pixel positions.
+
+2. `_parallel_predict_image` — the per-tile margin must match the FE's actual
+   required padding (`get_padding() * max(fe_scalings)`), and both margin and
+   maxblock must be aligned to the same downsampling grid.
+"""
+
+import torch  # noqa: F401  — must import before catboost/napari to avoid segfault on macOS
+import numpy as np
+import pytest
+
+from napari_convpaint.convpaint_model import ConvpaintModel
+from napari_convpaint.testing_data import (
+    generate_synthetic_square,
+    generate_synthetic_circle_annotation,
+)
+
+
+def _make_data(im_dims, square_dims, circle_offset, seed=0):
+    np.random.seed(seed)  # generate_synthetic_square uses the global RNG
+    im_hwc, _ = generate_synthetic_square(im_dims=im_dims, square_dims=square_dims, rgb=True)
+    # channel_mode='rgb' expects (C, H, W); generate_synthetic_square returns (H, W, C).
+    im = np.moveaxis(im_hwc, -1, 0)
+    im_annot = generate_synthetic_circle_annotation(
+        im_dims=im_dims,
+        circle1_xy=(im_dims[0] // 2, circle_offset),
+        circle2_xy=(im_dims[0] // 2, im_dims[1] // 2),
+    )
+    return im, im_annot
+
+
+def _build_model(alias, fe_scalings, tile_annotations, tile_image):
+    cp_model = ConvpaintModel(alias=alias)
+    cp_model.set_params(
+        fe_scalings=fe_scalings,
+        tile_annotations=tile_annotations,
+        tile_image=tile_image,
+        channel_mode="rgb",
+        normalize=1,
+        image_downsample=1,
+    )
+    return cp_model
+
+
+def _assert_equal_segmentations(seg_a, seg_b, label_a, label_b):
+    assert seg_a.shape == seg_b.shape, (
+        f"shape mismatch: {label_a}={seg_a.shape}, {label_b}={seg_b.shape}"
+    )
+    diff_mask = seg_a != seg_b
+    n_diff = int(diff_mask.sum())
+    n_total = int(seg_a.size)
+    info = ""
+    if n_diff > 0:
+        m = diff_mask.reshape(diff_mask.shape[-2:]) if diff_mask.ndim > 2 else diff_mask
+        ys, xs = np.where(m)
+        info = f" diff bbox rows=[{ys.min()},{ys.max()}] cols=[{xs.min()},{xs.max()}]"
+    assert n_diff == 0, (
+        f"{label_a} vs {label_b}: {n_diff}/{n_total} pixels differ "
+        f"({100 * n_diff / n_total:.3f}%).{info}"
+    )
+
+
+# --------------------------------------------------------------------------- #
+# tile_annotations: annotation tiling during training                          #
+# --------------------------------------------------------------------------- #
+
+@pytest.mark.parametrize(
+    "alias,fe_scalings",
+    [
+        ("vgg-m", [1]),  # 3 layers, total_stride=2 — misalignment by 1 (odd tile)
+        ("vgg-l", [1]),  # 5 layers, total_stride=4 — misalignment up to 3 (bigger hit)
+    ],
+)
+@pytest.mark.parametrize("use_rf", [True, False], ids=["rf", "catboost"])
+def test_tile_annotations_matches_no_tile(alias, fe_scalings, use_rf):
+    """Annotation tiling should not change the segmentation.
+
+    Train two models with identical seeds / params, differing only in
+    tile_annotations. If the FE-derived padding around each tile covers the
+    receptive field *and* the tile dims are aligned to the network's total
+    stride, the feature vectors at annotated pixels match, the (seeded)
+    classifier fits the same data, and segmentations are pixel-identical.
+
+    Both `use_rf=True` (RandomForest, random_state=0) and `use_rf=False`
+    (CatBoost, random_seed=0) are exercised — CatBoost is the UI default and
+    is the more sensitive bar (its bootstrap is order-aware on top of being
+    seeded). If features and row-order are bit-identical, both are bit-identical.
+    """
+    im, im_annot = _make_data(im_dims=(300, 300), square_dims=(70, 70), circle_offset=70)
+
+    def seg(tile_flag):
+        cp = _build_model(alias, fe_scalings, tile_annotations=tile_flag, tile_image=False)
+        cp.train(im, im_annot, fe_use_device="cpu", use_rf=use_rf)
+        return cp.segment(im, fe_use_device="cpu")
+
+    _assert_equal_segmentations(
+        seg(False), seg(True), "tile_annotations=False", "tile_annotations=True"
+    )
+
+
+# --------------------------------------------------------------------------- #
+# tile_image: image tiling during prediction                                   #
+# --------------------------------------------------------------------------- #
+
+@pytest.mark.parametrize(
+    "alias,fe_scalings,im_dims,square_dims,circle_offset",
+    [
+        # vgg-m no binning: required padding = 12 * 1 = 12 < 50 -> should pass.
+        ("vgg-m", [1], (1100, 1100), (220, 220), 300),
+        # vgg-l with binning: required padding = 36 * 4 = 144 > 50 -> should fail.
+        ("vgg-l", [1, 2, 4], (1100, 1100), (220, 220), 300),
+    ],
+)
+def test_tile_image_matches_no_tile(alias, fe_scalings, im_dims, square_dims, circle_offset):
+    """Image tiling at predict time should not change the segmentation.
+
+    Train one model with tile_annotations=False (so training is identical),
+    then predict with tile_image on and off. If `_parallel_predict_image`'s
+    per-tile margin is large enough for the FE's receptive field AND aligned
+    to the total stride, segmentations should be pixel-identical.
+    """
+    im, im_annot = _make_data(im_dims=im_dims, square_dims=square_dims, circle_offset=circle_offset)
+
+    cp = _build_model(alias, fe_scalings, tile_annotations=False, tile_image=False)
+    cp.train(im, im_annot, fe_use_device="cpu", use_rf=True)
+
+    cp._param.tile_image = False
+    seg_no_tile = cp.segment(im, fe_use_device="cpu")
+
+    cp._param.tile_image = True
+    seg_tiled = cp.segment(im, fe_use_device="cpu")
+
+    _assert_equal_segmentations(
+        seg_no_tile, seg_tiled, "tile_image=False", "tile_image=True"
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Gaussian-reach padding: high-frequency texture exposes blur boundary leak   #
+# --------------------------------------------------------------------------- #
+
+@pytest.mark.parametrize("use_rf", [True, False], ids=["rf", "catboost"])
+def test_tile_annotations_textured_image_default_vgg(use_rf):
+    """Default vgg16 (1 layer, fe_pad=1) with scalings [1,2,4] on textured input.
+
+    Pins tile/no-tile equivalence on high-frequency content where any
+    boundary-mode leakage in the downsample step would surface as feature
+    drift. Smooth synthetic shapes don't trigger it; white-noise + sinusoids
+    do. With block-mean downsampling (`scale_img` via `block_reduce`), each
+    output pixel reads exactly `scaling_factor` input pixels strictly inside
+    its block, so an aligned tile produces bit-identical features. Run for
+    both classifiers — CatBoost is the UI default and the more sensitive bar.
+    """
+    rng = np.random.default_rng(0)
+    h = w = 256
+    # White noise + sinusoidal stripes: every pixel has neighbours that differ
+    # strongly, so any boundary-mode blur produces visible feature drift.
+    yy, xx = np.meshgrid(np.arange(h), np.arange(w), indexing='ij')
+    stripes = 0.5 * np.sin(xx / 3.0) + 0.5 * np.sin(yy / 5.0)
+    im_2d = (rng.standard_normal((h, w)) + stripes).astype(np.float32)
+    im = np.stack([im_2d, im_2d, im_2d], axis=0)  # (3, H, W) for rgb mode
+
+    annot = np.zeros((h, w), dtype=np.uint16)
+    annot[40:55, 40:55] = 1
+    annot[180:195, 180:195] = 2
+    annot[100:103, 200:203] = 1  # tiny patch near boundary of its own tile
+
+    def seg(tile_flag):
+        cp = ConvpaintModel(alias='vgg')  # default vgg16, scalings [1,2,4]
+        cp.set_params(
+            tile_annotations=tile_flag,
+            tile_image=False,
+            channel_mode='rgb',
+            normalize=1,
+            image_downsample=1,
+        )
+        cp.train(im, annot, fe_use_device='cpu', use_rf=use_rf)
+        return cp.segment(im, fe_use_device='cpu')
+
+    _assert_equal_segmentations(
+        seg(False), seg(True),
+        'tile_annotations=False', 'tile_annotations=True',
+    )

--- a/src/napari_convpaint/_tests/test_utils.py
+++ b/src/napari_convpaint/_tests/test_utils.py
@@ -1,6 +1,10 @@
+import numpy as np
+import pytest
+
 from napari_convpaint import convpaint_model
 from napari_convpaint.feature_extractors import Hookmodel
 from napari_convpaint.param import Param
+from napari_convpaint.utils import scale_img
 import skimage
 
 def test_hook_model():
@@ -44,3 +48,27 @@ def test_filter_image():
     features = model.get_feature_image(data=image)
     assert features.shape[0] == 320, f'Expecting 320 features but got {features.shape[1]}'
     assert features.shape[1] == 128, f'Expecting 128 annotated pixels but got {features.shape[0]}'
+
+
+@pytest.mark.parametrize("upscale", [False, True], ids=["down", "up"])
+@pytest.mark.parametrize("factor", [2, 3, 5, 7])
+@pytest.mark.parametrize("H,W", [(256, 256), (255, 257), (100, 101)])
+def test_scale_img_image_and_labels_shape_match(factor, H, W, upscale):
+    """Image and labels paths must produce the same spatial shape after scale_img.
+
+    Regression: previously the downsample image path centre-cropped (floor(H/f))
+    while the labels path padded (ceil(H/f)), so non-aligned `image_downsample`
+    crashed `get_features_targets` (boolean-mask shape mismatch). After the fix,
+    both paths pre-pad to a multiple of f and reduce, so shapes always agree.
+    """
+    rng = np.random.default_rng(0)
+    img = rng.standard_normal((1, H, W)).astype(np.float32)
+    lbl = rng.integers(0, 3, size=(1, H, W), dtype=np.uint16)
+
+    img_out = scale_img(img, factor, upscale=upscale, input_type="img")
+    lbl_out = scale_img(lbl, factor, upscale=upscale, input_type="labels")
+
+    assert img_out.shape[-2:] == lbl_out.shape[-2:], (
+        f"shape mismatch at factor={factor}, upscale={upscale}, (H,W)=({H},{W}): "
+        f"img={img_out.shape[-2:]}  lbl={lbl_out.shape[-2:]}"
+    )

--- a/src/napari_convpaint/convpaint_model.py
+++ b/src/napari_convpaint/convpaint_model.py
@@ -19,6 +19,12 @@ from .feature_extractor import FeatureExtractor
 from .param import Param
 from . import utils
 
+# Target side-length of each block in `_parallel_predict_image`. The actual
+# block size is snapped down to the FE's alignment grid, so the effective
+# value is `(DEFAULT_TARGET_TILE_BLOCK // alignment) * alignment`.
+# If the FE gives a Tile block size, we use this instead.
+DEFAULT_TARGET_TILE_BLOCK = 1000
+
 class ConvpaintModel:
     """
     The `ConvpaintModel` class is the core of Convpaint and **combines feature extraction with pixel classification**.
@@ -197,7 +203,7 @@ class ConvpaintModel:
         try:
             module = importlib.import_module(module_path)
         except ImportError as e:
-            warnings.warn(f"Error when trying to import feature extractor module '{module_path}': {e}")
+            warnings.warn(f"Could not import feature extractor module '{module_path}': {e}")
             return
 
         model_names = getattr(module, "AVAILABLE_MODELS", None)
@@ -1043,8 +1049,9 @@ class ConvpaintModel:
         paddings = [self._get_overall_paddings(params_for_extract, d.shape) for d in data]
         # Pad the images and annotations with the correct padding size
         data = [utils.pad(d, p, input_type="img") for d, p in zip(data, paddings)]
-        # Save the padded shapes for reshaping/rescaling later
+        # Save the padded shapes and the per-image paddings for reshaping/cropping later
         self.padded_shapes = [d.shape for d in data]
+        self.paddings = paddings  # list of ((pad_top, pad_bottom), (pad_left, pad_right))
         if use_annots:
             annotations = [utils.pad(a, p, input_type="labels") for a, p in zip(annotations, paddings)]
         if memory_mode:
@@ -1081,8 +1088,10 @@ class ConvpaintModel:
         # Note: tiles are flattened (treating them as individual images)
         if params_for_extract.tile_annotations:
             if use_annots:
+                self._warn_if_global_context("tile_annotations")
                 coords = [None for _ in data] if coords is None else coords
-                tiles = [utils.tile_annot(d, a, c, p, plot_tiles=False)
+                alignment = self._get_fe_alignment(params_for_extract) # scalings_lcm * fe_patch
+                tiles = [utils.tile_annot(d, a, c, p, alignment=alignment, plot_tiles=False)
                         for d, a, c, p in zip(data, annotations, coords, paddings)]
                 data        = [t for trio in tiles for t in trio[0]]
                 annotations = [t for trio in tiles for t in trio[1]]
@@ -1146,6 +1155,7 @@ class ConvpaintModel:
         original_shapes = self.original_shapes # Before down/upsampling and padding
 
         # Only original (non-plane) images are expected here
+        paddings = self.paddings
         features = [
             self._restore_shape(
                 features[i],
@@ -1153,7 +1163,8 @@ class ConvpaintModel:
                 pre_pad_shapes[i],
                 original_shapes[i],
                 class_preds=class_output,
-                patched_features=self.fe_model.gives_patched_features()
+                patched_features=self.fe_model.gives_patched_features(),
+                paddings=paddings[i],
             )
             for i in range(len(features))
         ]
@@ -1283,7 +1294,7 @@ class ConvpaintModel:
 
     def _train(self, data, annotations, memory_mode=False, img_ids=None, use_rf=False,
                allow_writing_files=False, in_channels=None, skip_norm=False,
-               fe_use_device=None, clf_use_device=None):
+               fe_use_device=None, clf_use_device=None, sort_features=True):
         """
         Backend training method for the Convpaint model.
         """
@@ -1313,6 +1324,19 @@ class ConvpaintModel:
                 img_ids=img_ids, in_channels=in_channels, skip_norm=skip_norm, use_device=fe_use_device)
             # Get all annotations and features from the table
             features, targets = self._register_and_get_all_features_annots(feature_parts, annot_parts, coords, img_ids, scale)
+
+        # Sort (features, targets) into a canonical order so the classifier's
+        # seeded bootstrap sampling is invariant to the ordering produced by
+        # the feature-extraction path (tile_annotations on/off, memory_mode
+        # accumulation order across training rounds, etc.). Byte-view sort is
+        # ~23× faster than lexsort over F float columns because it hashes
+        # whole rows rather than walking them column-by-column.
+        if isinstance(features, np.ndarray) and features.size > 0 and sort_features:
+            features = np.ascontiguousarray(features)
+            row_view = features.view([('', features.dtype)] * features.shape[1]).ravel()
+            order = np.argsort(row_view, kind='stable')
+            features = features[order]
+            targets = targets[order]
 
         # Check if we have features and targets, and that we have at least two classes
         if len(features) == 0 or len(targets) == 0:
@@ -1573,12 +1597,14 @@ class ConvpaintModel:
         padded_shapes = self.padded_shapes # Saved when extracting features
         pre_pad_shapes = self.pre_pad_shapes # Saved when extracting features
         original_shapes = self.original_shapes # Saved when extracting features
+        paddings = self.paddings             # Saved when extracting features
         pred_reshaped = [self._restore_shape(predictions[i],
                                             padded_shapes[i],
                                             pre_pad_shapes[i],
                                             original_shapes[i],
                                             class_preds=False,
-                                            patched_features=self.fe_model.gives_patched_features())
+                                            patched_features=self.fe_model.gives_patched_features(),
+                                            paddings=paddings[i])
                          for i in range(len(predictions))]
 
         # If we want classes, take the argmax of the probabilities
@@ -1600,10 +1626,23 @@ class ConvpaintModel:
         NOTE: As opposed to other methods, this method only takes single images as input.
         """
 
-        maxblock = 1000
+        self._warn_if_global_context("tile_image")
+        # Derive the per-tile margin from the FE's required padding at the largest
+        # scaling, so every pixel in the kept region sees the same receptive-field
+        # context it would see during whole-image processing. Snap both the block
+        # size and the margin to the FE's downsampling grid so tile origins and
+        # sizes are multiples of it — otherwise the deeper feature maps upsample
+        # at a slightly different ratio than the whole-image pass and features
+        # drift relative to physical pixel positions (same class of bug as
+        # tile_annot without alignment).
+        fe_block_size = self.fe_model.get_tile_block_size()
+        block_size = fe_block_size if fe_block_size is not None else DEFAULT_TARGET_TILE_BLOCK
+        alignment = self._get_fe_alignment(self._param) # scalings_lcm * fe_patch
+        fe_margin = self.fe_model.get_padding() * int(np.max(self._param.fe_scalings))
+        margin = utils.align_up(fe_margin, alignment)
+        maxblock = max(alignment, (block_size // alignment) * alignment)
         nblocks_rows = image.shape[-2] // maxblock
         nblocks_cols = image.shape[-1] // maxblock
-        margin = 50
 
         image = self._prep_dims_single(image)[0] # NOTE: should technically not be necessary, as done outside
 
@@ -2006,14 +2045,42 @@ class ConvpaintModel:
                 new_param.set_single(key, enforced_params.get(key))
         return new_param
     
+    def _warn_if_global_context(self, mode):
+        """Emit a warning if the FE has global-context ops (e.g. SE blocks,
+        ViT attention) on the path to a selected layer — such features depend
+        on the whole input, so no finite padding makes tiled features match
+        whole-image features. `mode` is "tile_annotations" or "tile_image"."""
+        if self.fe_model.get_has_global_context():
+            warnings.warn(
+                f"{mode} is enabled but the feature extractor contains operators with "
+                "global receptive field (e.g. SE blocks in EfficientNet, attention in ViT). "
+                "Per-pixel features depend on the whole input, so tiling cannot produce the "
+                f"same features as whole-image processing. Consider disabling {mode} for this FE."
+            )
+
+    def _get_fe_alignment(self, param):
+        """Effective downsampling factor the FE imposes on the input grid.
+
+        Any sub-window of the image extracted for independent feature extraction
+        (annotation tiles, prediction tiles) must have spatial dims that are a
+        multiple of this value, otherwise the upsample ratio in
+        `rescale_features` differs from the whole-image pass and the resulting
+        features drift relative to their physical pixel position.
+        """
+        fe_scalings = param.fe_scalings
+        scalings_lcm = lcm(*fe_scalings)
+        fe_patch  = self.fe_model.get_patch_size()
+        return scalings_lcm * fe_patch
+
     def _get_overall_paddings(self, param, img_shape: Tuple[int, ...]):
         """
         Returns the overall padding sizes for the image in form ((top, bottom), (left, right)).
 
-        This takes into account the feature extractor's padding, its patch size and the image shape.
-        Makes sure, padding is at least the FE's padding at the largest downscaling factor,
-        and that the image is padded to a multiple of the patch size times at all scalings,
-        if the FE model uses patches.
+        Padding is at least the FE's receptive-field padding at the largest scaling,
+        and the padded image dims (and pad_top / pad_left) are multiples of the FE's
+        patch size at the LCM of fe_scalings. For Hookmodel, `patch_size` encodes
+        the internal MaxPool/Conv2d stride product (with `gives_patched_features=False`),
+        so the same alignment math handles both ViT-style and CNN feature extractors.
         """
         # Get the maximum scaling factor, base padding size and patch_size from the param and feature extractor
         fe_scalings = param.fe_scalings
@@ -2021,42 +2088,60 @@ class ConvpaintModel:
         fe_pad   = self.fe_model.get_padding()
         fe_patch = self.fe_model.get_patch_size()
 
-        # We need to pad at least the feature extractor's padding at the maximum scaling factor on each side
+        # `fe_pad` and `fe_patch` are two independent properties:
+        #   - `fe_pad = get_padding()` is the *receptive-field* requirement:
+        #     how many pixels of context must surround each output pixel so the
+        #     deepest feature equals the infinite-image answer. Scaled by
+        #     `max_scale` so the pyramid's coarsest level still has enough
+        #     context at its own resolution.
+        #   - `fe_patch = get_patch_size()` is the *grid alignment*
+        #     requirement: input dims must be a multiple of this so deeper
+        #     feature maps upsample cleanly (same ratio on whole image and on
+        #     sub-windows). Does not grow `min_pad`, only the alignment below.
         min_pad = fe_pad * max_scale
-        min_h = img_shape[-2] + 2 * min_pad
-        min_w = img_shape[-1] + 2 * min_pad
 
         # Calculate the least common multiple (LCM) of the feature extractor's scalings
         scalings_lcm = lcm(*fe_scalings)
-        # We need to pad to a multiple of the patch size at the lcm scaling factor (as it will be downscaled accordingly)
+        # Pad to a multiple of the patch size (for patch-based FEs, e.g. ViT)
+        # at the lcm scaling factor. Enforcing the patch alignment keeps the sub-pixel
+        # upsampling grid consistent between whole-image and tiled processing.
         patch_multiple = scalings_lcm * fe_patch
 
-        # Calculate the padding sizes for each dimension
-        padded_h = ( (min_h + patch_multiple - 1) // patch_multiple ) * patch_multiple
-        padded_w = ( (min_w + patch_multiple - 1) // patch_multiple ) * patch_multiple
-        pad_h = padded_h - img_shape[-2]
-        pad_w = padded_w - img_shape[-1]
+        # Snap the top/left pad up to a multiple of `patch_multiple` so the
+        # image content lives on the same downsampling grid regardless of how
+        # much the bottom/right must grow to reach a `padded_*` that is also a
+        # multiple of `patch_multiple`. Without aligned pad_top, a tile whose
+        # image-relative offset isn't a multiple of `patch_multiple` would have
+        # its content sit off-grid in the padded tile, shifting MaxPool windows
+        # and producing different features at the same physical pixel than the
+        # whole-image pass. This produces asymmetric paddings — `_restore_shape`
+        # passes the explicit pad_top/pad_left to `crop_to_shape` rather than
+        # assuming the old symmetric convention.
+        pad_top  = utils.align_up(min_pad, patch_multiple)
+        pad_left = utils.align_up(min_pad, patch_multiple)
+        padded_h = utils.align_up(pad_top + img_shape[-2] + min_pad, patch_multiple)
+        padded_w = utils.align_up(pad_left + img_shape[-1] + min_pad, patch_multiple)
+        pad_bottom = padded_h - img_shape[-2] - pad_top
+        pad_right  = padded_w - img_shape[-1] - pad_left
 
-        # Ensure that the padding is at least the minimum padding on each side, and a multiple of the lcm-scaled patch size
-        assert pad_h >= 2 * min_pad, f"Padding height {pad_h} is less than minimum padding 2x{min_pad}."
-        assert pad_w >= 2 * min_pad, f"Padding width {pad_w} is less than minimum padding 2x{min_pad}."
-        assert padded_h % patch_multiple == 0, f"Padded height {padded_h} is not a multiple of patch size {patch_multiple}."
-        assert padded_w % patch_multiple == 0, f"Padded width {padded_w} is not a multiple of patch size {patch_multiple}."
-
-        # Distribute to left/right and top/bottom, the bottom and right being 1 larger in uneven cases
-        pad_top = pad_h // 2
-        pad_bottom = pad_h - pad_top
-        pad_left = pad_w // 2
-        pad_right = pad_w - pad_left
+        assert pad_top    >= min_pad, f"pad_top {pad_top} < min_pad {min_pad}"
+        assert pad_bottom >= min_pad, f"pad_bottom {pad_bottom} < min_pad {min_pad}"
+        assert pad_left   >= min_pad, f"pad_left {pad_left} < min_pad {min_pad}"
+        assert pad_right  >= min_pad, f"pad_right {pad_right} < min_pad {min_pad}"
+        assert padded_h % patch_multiple == 0, f"Padded height {padded_h} is not a multiple of {patch_multiple}."
+        assert padded_w % patch_multiple == 0, f"Padded width {padded_w} is not a multiple of {patch_multiple}."
+        assert pad_top % patch_multiple == 0, f"pad_top {pad_top} is not aligned to {patch_multiple}."
+        assert pad_left % patch_multiple == 0, f"pad_left {pad_left} is not aligned to {patch_multiple}."
 
         # Return the overall padding sizes for the image
         return (pad_top, pad_bottom), (pad_left, pad_right)
 
-    def _restore_shape(self, outputs: np.ndarray, 
+    def _restore_shape(self, outputs: np.ndarray,
                              padded_shape: Tuple[int, ...],
                              pre_pad_shapes: Tuple[int, ...],
                              original_shape: Tuple[int, ...],
-                             class_preds: bool = False, patched_features: bool = False):
+                             class_preds: bool = False, patched_features: bool = False,
+                             paddings=None):
         """
         Reshapes outputs (prediction, probabilities, features) back to original spatial size,
         removing the padding and rescaling.
@@ -2076,6 +2161,11 @@ class ConvpaintModel:
         patched_features : bool
             If True, the features were extracted on a patch‐size resolution (e.g. DINOv2),
             so we need to rescale the outputs to the patch resolution before upsampling.
+        paddings : ((pad_top, pad_bottom), (pad_left, pad_right)), optional
+            The asymmetric padding applied by `_get_overall_paddings`. When
+            given, `crop_to_shape` uses `pad_top` / `pad_left` directly instead
+            of assuming symmetric padding. Required whenever padding was NOT
+            split evenly on each side (which is now the default).
 
         Returns
         ----------
@@ -2118,11 +2208,20 @@ class ConvpaintModel:
                 outputs_image, output_shape=new_shape,
                 order=order)
 
-        # 3) Remove padding
-        # Ensure to only remove the part of padding that was not removed by reduce_to_patch_multiple in the FE model
+        # 3) Remove padding. _get_overall_paddings produces asymmetric pad_top /
+        # pad_bottom (and likewise left/right) so pad_top lands on the FE's
+        # downsampling grid; pass those through explicitly rather than letting
+        # crop_to_shape fall back to its default symmetric split.
+        if paddings is not None:
+            crop_top = int(paddings[0][0])
+            crop_left = int(paddings[1][0])
+        else:
+            crop_top = crop_left = None
         outputs_image = utils.crop_to_shape(
             outputs_image,
-            pre_pad_shapes[-3:]
+            pre_pad_shapes[-3:],
+            crop_top=crop_top,
+            crop_left=crop_left,
         )
 
         # 4) Resize to original shape

--- a/src/napari_convpaint/convpaint_model.py
+++ b/src/napari_convpaint/convpaint_model.py
@@ -1615,7 +1615,7 @@ class ConvpaintModel:
             return pred_reshaped[0]
         return pred_reshaped
 
-    def _parallel_predict_image(self, image, return_proba=True, use_dask=False, fe_use_device=None):
+    def _parallel_predict_image(self, image, return_proba=True, use_dask=False, fe_use_device=None, plot_tiles=False):
         """
         Backend method to predict an image using tiling and parallelization.
         Returns the class probabilities and optionally the segmentation of the images.
@@ -1673,6 +1673,9 @@ class ConvpaintModel:
         new_min_col_ind_collection = []
         new_min_row_ind_collection = []
 
+        if plot_tiles:
+            img_to_plot = image.copy()
+
         for row in range(nblocks_rows+1):
             for col in range(nblocks_cols+1):
                 min_row = np.max([0, row*maxblock-margin])
@@ -1703,6 +1706,18 @@ class ConvpaintModel:
                     max_row = image.shape[-2]
 
                 image_block = image[..., min_row:max_row, min_col:max_col]
+
+                # For plotting:
+                # Take the entire image, add boarders for the block
+                if plot_tiles:
+                    img_to_plot[..., min_row, min_col:max_col] = 1
+                    img_to_plot[..., max_row-1, min_col:max_col] = 1
+                    img_to_plot[..., min_row:max_row, min_col] = 1
+                    img_to_plot[..., min_row:max_row, max_col-1] = 1
+                    img_to_plot[..., min_row_ind, min_col_ind:max_col_ind] = 0.5
+                    img_to_plot[..., max_row_ind-1, min_col_ind:max_col_ind] = 0.5
+                    img_to_plot[..., min_row_ind:max_row_ind, min_col_ind] = 0.5
+                    img_to_plot[..., min_row_ind:max_row_ind, max_col_ind-1] = 0.5
 
                 # Predict the block using dask or directly (with no normalization, as it is done outside)
                 if use_dask:
@@ -1746,7 +1761,12 @@ class ConvpaintModel:
                     min_row_ind_collection[k]:max_row_ind_collection[k],
                     min_col_ind_collection[k]:max_col_ind_collection[k]] = crop_out
             client.close()
-        
+
+        if plot_tiles:
+            from matplotlib import pyplot as plt
+            plt.imshow(img_to_plot[0, 0])
+            plt.show()
+
         return predicted_image_complete
 
     def _train_predict_image(self, image, annotations, use_rf=False, allow_writing_files=False,

--- a/src/napari_convpaint/convpaint_widget.py
+++ b/src/napari_convpaint/convpaint_widget.py
@@ -2408,8 +2408,14 @@ class ConvpaintWidget(QWidget):
                       fe_order = self.spin_interpolation_order.value(),
                       fe_use_min_features = self.check_use_min_features.isChecked())
 
-        # Get default non-FE params from temp model and update the GUI (also setting the params)
-        fe_defaults = self.temp_fe_defaults
+        # Get default non-FE params from a temp model built with the
+        # user-selected layers so defaults (e.g. tile_annotations) reflect
+        # has_global_context for the chosen layers rather than the FE's
+        # module-level defaults.
+        # Create a temp FE using the user-selected layers so defaults (like
+        # tile_annotations) reflect the chosen layers' properties.
+        temp_fe_model_for_defaults = self._cpm_class.create_fe(new_param.fe_name, layers=new_layers)
+        fe_defaults = temp_fe_model_for_defaults.get_default_params()
         adjusted_params = [] # List of adjusted parameters for raising a warning
         img = self._get_selected_img()
         data_dims = self._get_data_dims(img.data, img.ndim) if img is not None else None

--- a/src/napari_convpaint/feature_extractor.py
+++ b/src/napari_convpaint/feature_extractor.py
@@ -25,6 +25,10 @@ class FeatureExtractor:
         # Define specifications for the feature extractor model
         self.padding = 0
         self.patch_size = 1
+        self.has_global_context = False # Whether the FE contains operators that inject global (whole-input) context into per-pixel features 
+        # e.g. AdaptiveAvgPool2d inside SE blocks (EfficientNet), attention across all patches (ViT-like), etc
+        # For such FEs, tile_annotations / tile_image cannot match whole-image features at any finite padding
+        self.tile_block_size = None # If not None, this block size is used for tiling the image at segmentation
         self.num_input_channels = [1]
         self.norm_mode = "default"  # or "imagenet" or "percentile"
         self.rgb_input = False # Whether the model takes RGB input or not
@@ -100,6 +104,7 @@ class FeatureExtractor:
         def_param.fe_use_min_features = False
 
         # NOTE: Non-FE params should be set as default with caution
+        def_param.tile_annotations = not self.get_has_global_context()
 
         return def_param
     
@@ -129,6 +134,17 @@ class FeatureExtractor:
         if isinstance(self.proposed_scalings[0], int):
             return [self.proposed_scalings]
         return self.proposed_scalings
+    
+    def get_tile_block_size(self):
+        """
+        Get the tile block size that the feature extractor gives, if applicable. This is important for later tiling of the image at segmentation.
+
+        Returns:
+        ----------
+        tile_block_size : int or None
+            The tile block size that the feature extractor gives. If None, the default tile block size is used.
+        """
+        return self.tile_block_size
     
     def get_enforced_params(self, param=None):
         """
@@ -179,7 +195,8 @@ class FeatureExtractor:
         """
         Get the patch size that shall be used for feature extraction
         (images will be padded to multiples of patch-size).
-        Important: For some FEs this might have to be calculated based on certain parameters (e.g. layers).
+        Important: For some FEs this might have to be calculated based on certain parameters
+        (e.g. layers and the according stride given e.g. max_pool).
 
         Returns:
         ----------
@@ -187,6 +204,17 @@ class FeatureExtractor:
             The patch size that shall be used for feature extraction.
         """
         return self.patch_size
+
+    def get_has_global_context(self):
+        """
+        True if the FE contains operators that inject global (whole-input)
+        context into per-pixel features — e.g. AdaptiveAvgPool2d inside SE
+        blocks (EfficientNet), attention across all patches (ViT-like), etc.
+        For such FEs, tile_annotations / tile_image cannot match whole-image
+        features at any finite padding because each output pixel depends on
+        the entire input. Default False.
+        """
+        return self.has_global_context
 
     def get_num_input_channels(self):
         """
@@ -344,6 +372,7 @@ class FeatureExtractor:
             # Make sure the downscaled part is a multiple of the patch size
             patch_size = self.get_patch_size()
             pre_reduction_shape  = image_scaled.shape
+            # NOTE: reduce_to_patch_multiple should not do anything if the inputs are already multiples of the patch size at all scales
             image_scaled = reduce_to_patch_multiple(image_scaled, patch_size)
             reduced_shape = image_scaled.shape
 

--- a/src/napari_convpaint/feature_extractors/cellpose.py
+++ b/src/napari_convpaint/feature_extractors/cellpose.py
@@ -45,6 +45,7 @@ class CellposeFeatures(FeatureExtractor):
 
         super().__init__(model_name=model_name, model=model)
         self.patch_size = 8
+        self.has_global_context = True
         self.num_input_channels = [2]
         self.norm_mode = "percentile"
 

--- a/src/napari_convpaint/feature_extractors/combo_fe.py
+++ b/src/napari_convpaint/feature_extractors/combo_fe.py
@@ -102,7 +102,7 @@ class ComboFeatures(FeatureExtractor):
         return self.patch_size
     
     def get_has_global_context(self):
-        return self.model1.has_global_context() or self.model2.has_global_context()
+        return self.model1.get_has_global_context() or self.model2.get_has_global_context()
     
     def gives_patched_features(self):
         # Since we want to combine, we always rescale to image size, even if the models are patched

--- a/src/napari_convpaint/feature_extractors/combo_fe.py
+++ b/src/napari_convpaint/feature_extractors/combo_fe.py
@@ -101,6 +101,9 @@ class ComboFeatures(FeatureExtractor):
         self.patch_size = lcm(ps1, ps2)
         return self.patch_size
     
+    def get_has_global_context(self):
+        return self.model1.has_global_context() or self.model2.has_global_context()
+    
     def gives_patched_features(self):
         # Since we want to combine, we always rescale to image size, even if the models are patched
         # So, the combo FE itself is not patched, even if it works with a patch_size to comply with the models

--- a/src/napari_convpaint/feature_extractors/dino.py
+++ b/src/napari_convpaint/feature_extractors/dino.py
@@ -18,6 +18,7 @@ class DinoFeatures(FeatureExtractor):
         
         self.patch_size = 14
         self.padding = 0 # Note: final padding is automatically 1/2 patch size
+        self.has_global_context = True
         self.num_input_channels = [3]
         self.norm_mode = "imagenet"  # DINOv2 expects ImageNet normalization
         self.rgb_input = True  # DINOv2 expects RGB input

--- a/src/napari_convpaint/feature_extractors/dino_jafar.py
+++ b/src/napari_convpaint/feature_extractors/dino_jafar.py
@@ -45,6 +45,7 @@ class DinoJafarFeatures(FeatureExtractor):
         
         self.patch_size = 14          # token size of ViT
         self.padding    = 0           # model-internal extra pad (none)
+        self.has_global_context = True # DINOv2 and JAFAR's upsampler use global attention
         self.num_input_channels = [3] # RGB
         self.norm_mode = "imagenet"  # DINOv2 expects ImageNet normalization
         self.rgb_input = True       # expects RGB input

--- a/src/napari_convpaint/feature_extractors/gaussian.py
+++ b/src/napari_convpaint/feature_extractors/gaussian.py
@@ -1,3 +1,4 @@
+import math
 import skimage
 import numpy as np
 
@@ -14,7 +15,9 @@ class GaussianFeatures(FeatureExtractor):
     def __init__(self, model_name='gaussian_features', sigma=3, **kwargs):
         super().__init__(model_name=model_name)
         self.sigma = sigma
-        self.padding = 2*sigma # Padding established empirically to avoid edge effects
+        # skimage.filters.gaussian uses truncate=4.0 by default, so each
+        # output pixel reads `ceil(4 * sigma)` input pixels on each side.
+        self.padding = math.ceil(4 * sigma)
 
     def get_description(self):
         return "Minimal model to easily and rapidly extract basic image features."

--- a/src/napari_convpaint/feature_extractors/ilastik.py
+++ b/src/napari_convpaint/feature_extractors/ilastik.py
@@ -1,7 +1,31 @@
 import itertools
+import math
 import numpy as np
 import importlib.util
 import warnings
+
+# fastfilters truncates each Gaussian / derivative kernel at half-length
+# `ceil((3 + order/2) * sigma)` (fir_kernel.c). `SingleFilter.kernel_size` in
+# ilastik.napari.filters returns `half_length + 1`, so `kernel_size // 2`
+# under-pads by ~2×. For compound filters the reaches chain: StructureTensor
+# computes a gradient at `inner_scale` (order=1) then smooths with a Gaussian
+# at `outer_scale` (order=0), and the two half-lengths *add*. DifferenceOfGaussians
+# runs two independent Gaussian smoothings and takes their difference, so the
+# reach is the max of the two.
+
+def _gauss_half_length(sigma, order):
+    """fastfilters' default Gaussian kernel half-length (each side, in pixels)
+    for derivative order `order`. Source: fir_kernel.c."""
+    return math.ceil((3.0 + 0.5 * order) * sigma)
+
+def _filter_reach(f):
+    """Boundary reach (pixels each side) of an ilastik FilterSet member."""
+    name = type(f).__name__
+    if name == "StructureTensorEigenvalues":
+        return _gauss_half_length(f.inner_k * f.scale, 1) + _gauss_half_length(f.scale, 0)
+    if name == "DifferenceOfGaussians":
+        return max(_gauss_half_length(f.scale, 0), _gauss_half_length(f.inner_k * f.scale, 0))
+    return _gauss_half_length(f.scale, f.order)
 
 def import_ilastik_filters():
     try:
@@ -61,7 +85,7 @@ class IlastikFeatures(FeatureExtractor):
         global FILTER_SET
         FILTER_SET = create_filter_set()
         super().__init__(model_name=model_name)
-        self.padding = FILTER_SET.kernel_size // 2
+        self.padding = max(_filter_reach(f) for f in FILTER_SET.filters)
 
     def get_description(self):
         return "Extraction of image features using the full filter set of the popular segmentation tool Ilastik."

--- a/src/napari_convpaint/feature_extractors/nnlayers.py
+++ b/src/napari_convpaint/feature_extractors/nnlayers.py
@@ -152,7 +152,7 @@ class Hookmodel(FeatureExtractor):
             param.fe_scalings = [1,2]
             param.fe_layers = self.selectable_layer_keys[:3] # Use the first 3 layers by default
 
-        # param.tile_annotations = True # Removed this in favour of setting it to not self.get_has_global_context() in the feature extractor superclass
+        # Note that tile_annotations is set to `not self.get_has_global_context()` in the feature extractor superclass
 
         return param
 
@@ -234,46 +234,6 @@ class Hookmodel(FeatureExtractor):
         self.padding = rf // 2
         self.patch_size = stride
         self.has_global_context = has_global
-
-    def get_max_kernel_size_and_depth(self):
-        """
-        Given a hookmodel, find the maximum kernel size needed for the deepest layer.
-        NOTE: This has been replaced by the more rigorous receptive field calculation above, but is kept here for reference.
-        
-        Parameters: None
-        ----------
-        
-        Returns
-        -------
-        max_kernel_size: int
-            maximum kernel size needed for the deepest layer
-        conv_depth: int
-            number of convolutional layers until the deepest layer (including the deepest layer)
-        """
-        # Initialize variables
-        max_kernel_size = 1
-        current_total_pool = 1
-        conv_depth = 1
-
-        if len(self.selected_layers) == 0:
-            # no layers selected yet
-            return 0
-        
-        # Find out which is the deepest layer
-        latest_layer = self.module_dict[self.selected_layers[-1]]
-        # Iterate over all layers to find the maximum kernel size
-        for curr_layer_key, curr_layer in self.module_dict.items():
-            # If a maxpool layer is involved, kernel size needs to be multiplied for all future convolutions
-            if "MaxPool2d" in str(curr_layer) and hasattr(curr_layer, 'kernel_size'):
-                current_total_pool *= curr_layer.kernel_size
-            # For each convolution, multiply the kernel size with the current total pool
-            elif "Conv2d" in str(curr_layer) and hasattr(curr_layer, 'kernel_size'):
-                conv_depth += 1
-                max_kernel_size = current_total_pool * curr_layer.kernel_size[0]
-            # Only iterate until the latest selected layer
-            if curr_layer == latest_layer:
-                break
-        return max_kernel_size, conv_depth
     
     def get_num_input_channels(self):
         return [self.named_modules[0][1].in_channels]

--- a/src/napari_convpaint/feature_extractors/nnlayers.py
+++ b/src/napari_convpaint/feature_extractors/nnlayers.py
@@ -152,7 +152,7 @@ class Hookmodel(FeatureExtractor):
             param.fe_scalings = [1,2]
             param.fe_layers = self.selectable_layer_keys[:3] # Use the first 3 layers by default
 
-        param.tile_annotations = True # Overwrite non-FE settings
+        # param.tile_annotations = True # Removed this in favour of setting it to not self.get_has_global_context() in the feature extractor superclass
 
         return param
 
@@ -178,14 +178,67 @@ class Hookmodel(FeatureExtractor):
             return [self.selectable_layer_keys[x] for x in layers]
         else:
             return layers
-    
-    def get_padding(self):
-        ks, depth = self.get_max_kernel_size_and_depth()
-        return ks * depth // 2  # Padding established empirically to avoid significant edge effects
+
+    def gives_patched_features(self):
+        # We do define patches by the stride of the CNN, as we want the windows to align with the downsampling grid of the CNN.
+        # However, unlike e.g. ViTs, CNNs give per-pixel features, not patch-level features.
+        # So we return False here, even if the patch size is >1.
+        return False
+
+    def _compute_nn_properties(self):
+        """Walk the network in execution order, accumulating receptive field,
+        total stride, and whether any global-context op was encountered, up to
+        and including the deepest selected layer. RF grows by `(k-1) * stride`
+        on Conv2d/MaxPool/AvgPool; stride multiplies by `s` on strided Conv2d
+        and pooling.
+        padding:
+        Rigorous half-receptive-field bound: `floor(RF / 2)` — the minimum
+        context around an image pixel so its deepest selected feature equals
+        the infinite-image answer. `_get_overall_paddings` separately snaps
+        the padding up to a multiple of `get_total_stride()`.
+        patch_size (stride):
+        The total internal stride of the FE up to the deepest selected layer.
+        For CNNs with MaxPool, this is the minimum tile size for which features
+        can match whole-image features. For patch-based FEs (e.g. ViT), this
+        is the patch size.
+        has_global_context:
+        True if an AdaptiveAvgPool2d / AdaptiveMaxPool2d sits on the path to
+        the deepest selected layer (e.g. SE blocks in EfficientNet). Such
+        operators give every output pixel dependence on the entire input —
+        no finite padding makes tile features match whole-image features.
+        """
+        if len(self.selected_layers) == 0:
+            return 1, False
+        rf = 1
+        stride = 1
+        has_global = False
+        latest_layer = self.module_dict[self.selected_layers[-1]]
+        for _, curr_layer in self.module_dict.items():
+            if isinstance(curr_layer, (nn.AdaptiveAvgPool2d, nn.AdaptiveMaxPool2d)):
+                has_global = True
+            k = s = None
+            if isinstance(curr_layer, nn.Conv2d):
+                k = curr_layer.kernel_size[0] if isinstance(curr_layer.kernel_size, tuple) else curr_layer.kernel_size
+                s = curr_layer.stride[0] if isinstance(curr_layer.stride, tuple) else curr_layer.stride
+            elif isinstance(curr_layer, (nn.MaxPool2d, nn.AvgPool2d)) and hasattr(curr_layer, 'kernel_size'):
+                ks = curr_layer.kernel_size
+                st = curr_layer.stride if curr_layer.stride is not None else ks
+                k = ks[0] if isinstance(ks, tuple) else ks
+                s = st[0] if isinstance(st, tuple) else st
+            if k is not None:
+                rf = rf + (k - 1) * stride
+                stride = stride * s
+            if curr_layer is latest_layer:
+                break
+
+        self.padding = rf // 2
+        self.patch_size = stride
+        self.has_global_context = has_global
 
     def get_max_kernel_size_and_depth(self):
         """
         Given a hookmodel, find the maximum kernel size needed for the deepest layer.
+        NOTE: This has been replaced by the more rigorous receptive field calculation above, but is kept here for reference.
         
         Parameters: None
         ----------
@@ -194,6 +247,8 @@ class Hookmodel(FeatureExtractor):
         -------
         max_kernel_size: int
             maximum kernel size needed for the deepest layer
+        conv_depth: int
+            number of convolutional layers until the deepest layer (including the deepest layer)
         """
         # Initialize variables
         max_kernel_size = 1
@@ -271,3 +326,4 @@ class Hookmodel(FeatureExtractor):
             else:
                 # print(f"registering hook for layer {selected_layers[ind]}")
                 self.module_dict[selected_layers[ind]].register_forward_hook(self.hook_normal)
+        self._compute_nn_properties() # Recompute RF, patch size, and global context properties based on the new layers

--- a/src/napari_convpaint/feature_extractors/template.py
+++ b/src/napari_convpaint/feature_extractors/template.py
@@ -24,8 +24,9 @@ class GaussianFeatures(FeatureExtractor):
         super().__init__(model_name=model_name)
 
         # Define specifications for the feature extractor model, if necessary; examples:
-        # self.padding = 0
-        # self.patch_size = 1
+        # self.padding = 0 # If the model needs a certain padding around the extracted pixel, set it here. This is used to calculate the necessary padding for tiling.
+        # self.patch_size = 1 # If the model produces features at a lower resolution than the input image, e.g. because of pooling or ViT patching, set the patch size here. This is used to calculate the necessary padding and alignment for tiling.
+        # self.has_global_context = False # True if the model's features at a pixel depend on the whole image (e.g. ViT-style global attention) rather than just a local neighborhood (e.g. CNN with small kernels and little pooling)
         # self.num_input_channels = [1]
         # self.norm_mode = "default" # or "imagenet" or "percentile"
         # self.rgb_input = False # True if the model takes RGB input

--- a/src/napari_convpaint/utils.py
+++ b/src/napari_convpaint/utils.py
@@ -194,25 +194,26 @@ def scale_img(image, scaling_factor, upscale=False, input_type="img", plot_resul
     
     # Else DOWNSCALE the image
 
-    # IMAGES
-    # OLD: by gaussian filter and striding
-    if input_type in ('img', 'image') and use_gaussian_scaling:
-        return scale_with_gaussian(image, scaling_factor, plot_blurred=plot_result)
-
-    # For IMAGE WITH BLOCK_REDUCE, LABELS and COORDINATES, we pad to the next multiple of the scaling factor,
+    # Pad to the next multiple of the scaling factor,
     # distributing on each side (with 1 pixel more on bottom/right if uneven)
     if image.shape[-2] % scaling_factor != 0 or image.shape[-1] % scaling_factor != 0:
-        # Calculate padding sizes
         pad_h = (scaling_factor - (image.shape[-2] % scaling_factor)) % scaling_factor
         pad_w = (scaling_factor - (image.shape[-1] % scaling_factor)) % scaling_factor
         pad_top, pad_left = pad_h // 2, pad_w // 2
         pad_bot, pad_right = pad_h - pad_top, pad_w - pad_left
         # Pad the image
         image = pad(image, (pad_top, pad_bot, pad_left, pad_right), input_type=input_type)
-
-    # For IMAGES, use block_reduce with mean
-    if input_type in ('img', 'image'):
-        return scale_with_block_mean(image, scaling_factor)
+    
+    # IMAGES
+    img_strings = ('img', 'image', 'images') # Allow some flexibility in the input type string for images (but pass 'img' downstream)
+    if input_type in img_strings:
+        input_type = 'img'
+        if not use_gaussian_scaling:
+            # NEW (default): use block_reduce with mean
+            return scale_with_block_mean(image, scaling_factor)
+        else:
+            # OLD: by gaussian filter and striding
+            return scale_with_gaussian(image, scaling_factor, plot_blurred=plot_result)
 
     # For LABELS and COORDINATES, slice the last two dimensions
     slice_start = (0, 0) #((image.shape[-2] % scaling_factor) // 2,
@@ -282,7 +283,11 @@ def scale_with_block_mean(image, scaling_factor):
     """Rescale image by block-mean downsampling. Reads exactly `scaling_factor` input
     pixels per output pixel — strictly local — so a sub-window aligned to
     `scaling_factor` produces bit-identical features to the whole-image pass
-    at the same physical positions (no boundary-mode blur leak)."""
+    at the same physical positions (no boundary-mode blur leak).
+    
+    Intended for use on images that have been padded to a multiple of `scaling_factor`.
+    But also works otherwise, in which case it centre-crops to a multiple of `scaling_factor` before block-reducing.
+    """
     # `block_reduce` needs strided ndarray semantics; materialise dask etc.
     image = np.asarray(image)
     H, W = image.shape[-2:]
@@ -299,14 +304,20 @@ def scale_with_block_mean(image, scaling_factor):
     return block_reduce(image, block_size=block_shape, func=np.mean)
 
 def scale_with_gaussian(image, scaling_factor, plot_blurred=False):
+    """Rescale image by Gaussian-blur + strided downsampling. The blur is intended to mitigate aliasing artifacts from the strided downsampling,
+    but it also causes some bleed across blocks, so features at a given position are influenced by a slightly larger area of the input image compared to block-mean downscaling.
+
+    Intended for use on images that have been padded to a multiple of `scaling_factor`.
+    But also works otherwise, in which case it centre-crops to a multiple of `scaling_factor` before block-reducing.
+    """
     # Apply a small Gaussian blur to avoid aliasing
     sigma = 0.4 * scaling_factor
     sigma = [0] * (image.ndim - 2) + [sigma, sigma]  # Add zeros for batch and channel dimensions
     blurred_img = gaussian_filter(image, sigma=sigma)  # assuming shape (..., H, W)
     # Downsample by striding
     H, W = image.shape[-2:]
-    start_h = (H % scaling_factor) // 2 # Move the start such that the image is centered
-    start_w = (W % scaling_factor) // 2 # Move the start such that the image is centered
+    start_h = scaling_factor // 2 # Move the start such that the image is centered (and with padding, the picked pixels align at the center of blocks)
+    start_w = scaling_factor // 2 # Move the start such that the image is centered (and with padding, the picked pixels align at the center of blocks)
     scaled_img = blurred_img[..., start_h::scaling_factor, start_w::scaling_factor]
 
     if plot_blurred:

--- a/src/napari_convpaint/utils.py
+++ b/src/napari_convpaint/utils.py
@@ -194,25 +194,27 @@ def scale_img(image, scaling_factor, upscale=False, input_type="img", plot_resul
     
     # Else DOWNSCALE the image
 
+    # Pre-pad to a multiple of `scaling_factor` so the reduction is exact and image,
+    # labels, and coords all produce the same output shape. Padding mode is per
+    # input_type (reflect for images, 0 for labels, -1 for coords) via `pad()`.
+    if image.shape[-2] % scaling_factor != 0 or image.shape[-1] % scaling_factor != 0:
+        pad_h = (scaling_factor - (image.shape[-2] % scaling_factor)) % scaling_factor
+        pad_w = (scaling_factor - (image.shape[-1] % scaling_factor)) % scaling_factor
+        pad_top, pad_left = pad_h // 2, pad_w // 2
+        pad_bot, pad_right = pad_h - pad_top, pad_w - pad_left
+        image = pad(image, (pad_top, pad_bot, pad_left, pad_right), input_type=input_type)
+
     # IMAGES
     if input_type == 'img':
         if not use_gaussian_scaling:
-            # NEW: By block-mean
+            # NEW: block-mean. Input is aligned by the pre-pad above, satisfying
+            # scale_with_block_mean's precondition.
             return scale_with_block_mean(image, scaling_factor)
         else:
             # OLD: by gaussian filter and striding
             return scale_with_gaussian(image, scaling_factor, plot_blurred=plot_result)
 
     # For LABELS and COORDINATES, we slice/stack the image to apply the downscaling along new axes
-    # First, we pad to the next multiple of the scaling factor, distributing on each side (with 1 pixel more on bottom/right if uneven)
-    if image.shape[-2] % scaling_factor != 0 or image.shape[-1] % scaling_factor != 0:
-        # Calculate padding sizes
-        pad_h = (scaling_factor - (image.shape[-2] % scaling_factor)) % scaling_factor
-        pad_w = (scaling_factor - (image.shape[-1] % scaling_factor)) % scaling_factor
-        pad_top, pad_left = pad_h // 2, pad_w // 2
-        pad_bot, pad_right = pad_h - pad_top, pad_w - pad_left
-        # Pad the image
-        image = pad(image, (pad_top, pad_bot, pad_left, pad_right), input_type=input_type)
     # Slice the last two dimensions
     slice_start = (0, 0) #((image.shape[-2] % scaling_factor) // 2,
                     #  (image.shape[-1] % scaling_factor) // 2)
@@ -279,21 +281,16 @@ def scale_img(image, scaling_factor, upscale=False, input_type="img", plot_resul
     
 def scale_with_block_mean(image, scaling_factor):
     """Rescale image by block-mean downsampling. Reads exactly `scaling_factor` input
-    pixels per output pixel — strictly local — so a sub-window aligned to
-    `scaling_factor` produces bit-identical features to the whole-image pass
-    at the same physical positions (no boundary-mode blur leak)."""
+    pixels per output pixel — strictly local, no boundary-mode blur leak — so a
+    sub-window aligned to `scaling_factor` produces bit-identical features to the
+    whole-image pass at the same physical positions.
+
+    Precondition: H and W must be multiples of `scaling_factor`. All in-tree
+    callers ensure this — `scale_img` pre-pads, and the FE pyramid receives
+    input aligned by `_get_overall_paddings`.
+    """
     # `block_reduce` needs strided ndarray semantics; materialise dask etc.
     image = np.asarray(image)
-    H, W = image.shape[-2:]
-    # Centre-crop to a multiple of `scaling_factor` (matches the prior
-    # centring behaviour). In convpaint's pipeline `_get_overall_paddings`
-    # already pads to a multiple of all scalings, so this is normally a no-op.
-    crop_h = H % scaling_factor
-    crop_w = W % scaling_factor
-    if crop_h or crop_w:
-        sh = crop_h // 2
-        sw = crop_w // 2
-        image = image[..., sh:H - (crop_h - sh), sw:W - (crop_w - sw)]
     block_shape = (1,) * (image.ndim - 2) + (scaling_factor, scaling_factor)
     return block_reduce(image, block_size=block_shape, func=np.mean)
 

--- a/src/napari_convpaint/utils.py
+++ b/src/napari_convpaint/utils.py
@@ -2,6 +2,7 @@ import warnings
 import torch
 import numpy as np
 from scipy.ndimage import gaussian_filter
+from skimage.measure import block_reduce
 import skimage.transform
 import skimage.morphology as morph
 from joblib import Parallel, delayed
@@ -97,8 +98,8 @@ def guided_model_download(model_file: str, model_url: str, model_dir: str = None
     # Try importing Napari tools
     use_napari = False
     try:
-        from napari.utils.progress import progress as napari_s
-        from napari.utils.notifications import show_info, shs
+        from napari.utils.progress import progress as napari_progress
+        from napari.utils.notifications import show_info, show_error
         import napari
         if napari.current_viewer():
             use_napari = True
@@ -191,24 +192,12 @@ def scale_img(image, scaling_factor, upscale=False, input_type="img"):
     
     # Else DOWNSCALE the image
 
-    # IMAGES by gaussian filter and striding
+    # IMAGES
     if input_type == 'img':
-        # Apply a small Gaussian blur to avoid aliasing
-        sigma = 0.4 * scaling_factor
-        sigma = [0] * (image.ndim - 2) + [sigma, sigma]  # Add zeros for batch and channel dimensions
-        blurred_img = gaussian_filter(image, sigma=sigma)  # assuming shape (..., H, W)
-        # Downsample by striding
-        H, W = image.shape[-2:]
-        start_h = (H % scaling_factor) // 2 # Move the start such that the image is centered
-        start_w = (W % scaling_factor) // 2 # Move the start such that the image is centered
-        scaled_img = blurred_img[..., start_h::scaling_factor, start_w::scaling_factor]
-        # from matplotlib import pyplot as plt
-        # fig, ax = plt.subplots(1, 3, figsize=(15, 5))
-        # ax[0].imshow(image[0,0,...], cmap='gray')
-        # ax[1].imshow(blurred_img[0,0,...], cmap='gray')
-        # ax[2].imshow(scaled_img[0,0,...], cmap='gray')
-        # plt.show()
-        return scaled_img
+        # NEW: By block-mean
+        return scale_with_block_mean(image, scaling_factor)
+        # OLD: by gaussian filter and striding
+        return scale_with_gaussian(image, scaling_factor)
 
     # For LABELS and COORDINATES, we slice/stack the image to apply the downscaling along new axes
     # First, we pad to the next multiple of the scaling factor, distributing on each side (with 1 pixel more on bottom/right if uneven)
@@ -282,6 +271,44 @@ def scale_img(image, scaling_factor, upscale=False, input_type="img"):
     else:
         raise ValueError(f"Unknown input type: {input_type}. Supported types are 'img', 'labels', and 'coords'.")
     
+def scale_with_block_mean(image, scaling_factor):
+    """Rescale image by block-mean downsampling. Reads exactly `scaling_factor` input
+    pixels per output pixel — strictly local — so a sub-window aligned to
+    `scaling_factor` produces bit-identical features to the whole-image pass
+    at the same physical positions (no boundary-mode blur leak)."""
+    # `block_reduce` needs strided ndarray semantics; materialise dask etc.
+    image = np.asarray(image)
+    H, W = image.shape[-2:]
+    # Centre-crop to a multiple of `scaling_factor` (matches the prior
+    # centring behaviour). In convpaint's pipeline `_get_overall_paddings`
+    # already pads to a multiple of all scalings, so this is normally a no-op.
+    crop_h = H % scaling_factor
+    crop_w = W % scaling_factor
+    if crop_h or crop_w:
+        sh = crop_h // 2
+        sw = crop_w // 2
+        image = image[..., sh:H - (crop_h - sh), sw:W - (crop_w - sw)]
+    block_shape = (1,) * (image.ndim - 2) + (scaling_factor, scaling_factor)
+    return block_reduce(image, block_size=block_shape, func=np.mean)
+
+def scale_with_gaussian(image, scaling_factor):
+    # Apply a small Gaussian blur to avoid aliasing
+    sigma = 0.4 * scaling_factor
+    sigma = [0] * (image.ndim - 2) + [sigma, sigma]  # Add zeros for batch and channel dimensions
+    blurred_img = gaussian_filter(image, sigma=sigma)  # assuming shape (..., H, W)
+    # Downsample by striding
+    H, W = image.shape[-2:]
+    start_h = (H % scaling_factor) // 2 # Move the start such that the image is centered
+    start_w = (W % scaling_factor) // 2 # Move the start such that the image is centered
+    scaled_img = blurred_img[..., start_h::scaling_factor, start_w::scaling_factor]
+    # from matplotlib import pyplot as plt
+    # fig, ax = plt.subplots(1, 3, figsize=(15, 5))
+    # ax[0].imshow(image[0,0,...], cmap='gray')
+    # ax[1].imshow(blurred_img[0,0,...], cmap='gray')
+    # ax[2].imshow(scaled_img[0,0,...], cmap='gray')
+    # plt.show()
+    return scaled_img
+
 def fast_mode(arr, axis):
     """
     Fast mode pooling assuming integer values >= 0
@@ -490,11 +517,21 @@ def pad_to_shape(feat, target_shape):
     return np.pad(feat, pad, mode='constant')
 
 
-def crop_to_shape(arr, target_shape):
+def align_up(val, alignment):
+    """Smallest multiple of `alignment` that is >= `val`. Alignment must be >= 1."""
+    return ((val + alignment - 1) // alignment) * alignment
+
+
+def crop_to_shape(arr, target_shape, crop_top=None, crop_left=None):
     """
-    Crops the spatial dimensions (last two) of `arr` symmetrically to match `target_shape`.
-    In case of odd number of pixels to remove, top and left crops are 1 larger than bottom and right
-    to reverse a prior reduction that removed more from bottom/right (from reduce_to_patch_multiple).
+    Crops the spatial dimensions (last two) of `arr` to match `target_shape`.
+
+    If `crop_top` / `crop_left` are given (for inverting an asymmetric pad),
+    they're used directly — the bottom/right crop is whatever's left. Without
+    them, crops symmetrically with bottom/right one larger on odd deltas (this
+    matches the old policy in `_get_overall_paddings`, and the fall backs policies in
+    `reduce_to_patch_multiple` which removes more from bottom/right and
+    `pad_to_shape` which gives bottom/right the extra pixel).
 
     Parameters
     ----------
@@ -502,6 +539,8 @@ def crop_to_shape(arr, target_shape):
         Input array with spatial dimensions in the last two axes.
     target_shape : tuple
         Desired shape for the last two dimensions: (..., H_target, W_target)
+    crop_top, crop_left : int, optional
+        Explicit top/left crop amounts (for inverting asymmetric pads).
 
     Returns
     -------
@@ -517,10 +556,15 @@ def crop_to_shape(arr, target_shape):
     crop_h = current_h - target_h
     crop_w = current_w - target_w
 
-    crop_top = (crop_h + 1) // 2  # top gets more when odd
+    if crop_top is None:
+        crop_top = crop_h // 2  # top gets the smaller half when odd; bottom gets the extra
+    if crop_left is None:
+        crop_left = crop_w // 2
     crop_bottom = crop_h - crop_top
-    crop_left = (crop_w + 1) // 2  # left gets more when odd
-    crop_right = crop_w - crop_left
+    crop_right  = crop_w - crop_left
+
+    assert crop_bottom >= 0 and crop_right >= 0, \
+        f"crop_top/left {crop_top},{crop_left} exceed delta {crop_h},{crop_w}"
 
     h_end = -crop_bottom if crop_bottom > 0 else None
     w_end = -crop_right if crop_right > 0 else None
@@ -569,7 +613,7 @@ def get_annot_planes(img, annot=None, coords=None):
         coords_planes = None
     return img_planes, annot_planes, coords_planes
 
-def tile_annot(img, annot, coords, padding, plot_tiles=False):
+def tile_annot(img, annot, coords, padding, alignment=1, plot_tiles=False):
     """
     Tile the image and annotations into patches of the size of the annotations.
     Takes a number of pixels equal to 'padding' more than the bounding box of the annotation.
@@ -585,6 +629,11 @@ def tile_annot(img, annot, coords, padding, plot_tiles=False):
         Padding size to be added to the bounding box of the annotations.
         If an int is provided, it is applied to all sides.
         If a tuple is provided, it should be of the form (pad_top, pad_bottom, pad_left, pad_right).
+    alignment : int, optional
+        Snap each tile's top/left origin down and its height/width up to the next
+        multiple of `alignment`. Must match the FE's effective downsampling factor
+        (patch_size * total_stride * lcm(scalings)) for tile-level features to
+        align with whole-image features. Default 1 (no alignment).
 
     Returns:
     ----------
@@ -604,7 +653,7 @@ def tile_annot(img, annot, coords, padding, plot_tiles=False):
         pad_bottom, pad_right = padding # And pad the same on both sides
     else:
         raise ValueError(f"Padding must be an int or a tuple of 2 or 4 ints, got {padding}.")
-    
+
     # Find the bounding boxes of the annotations
     annot_regions = skimage.morphology.label(annot > 0)
     regions = skimage.measure.regionprops(annot_regions)
@@ -617,7 +666,9 @@ def tile_annot(img, annot, coords, padding, plot_tiles=False):
     if plot_tiles:
         im_to_show = img[0,0,...].copy()
         im_to_show[annot[0]>0] = 0
-    
+
+    img_h, img_w = img.shape[-2], img.shape[-1]
+
     for region in regions:
         # Get the bounding box of the annotation
         z_min, y_min, x_min, z_max, y_max, x_max = region.bbox
@@ -633,6 +684,18 @@ def tile_annot(img, annot, coords, padding, plot_tiles=False):
         y_max += pad_bottom
         x_min -= pad_left
         x_max += pad_right
+
+        # Snap tile bounds to the FE's downsampling grid. The origin is floored
+        # and the far edge is ceiled to the next multiple of `alignment`, so the
+        # MaxPool windowing inside the tile matches the whole-padded-image pass
+        # and the upsample ratio is an exact integer. Bounds are also clamped to
+        # the image; since `_get_overall_paddings` now pads the whole image to a
+        # multiple of `alignment`, clamping preserves the grid alignment too.
+        if alignment > 1:
+            y_min = max(0, (y_min // alignment) * alignment)
+            x_min = max(0, (x_min // alignment) * alignment)
+            y_max = min(img_h, align_up(y_max, alignment))
+            x_max = min(img_w, align_up(x_max, alignment))
 
         if plot_tiles:
             # Draw the bounding box WITH PADDING on the image

--- a/src/napari_convpaint/utils.py
+++ b/src/napari_convpaint/utils.py
@@ -153,7 +153,7 @@ def guided_model_download(model_file: str, model_url: str, model_dir: str = None
 
 ### SCALING AND RESCALING
 
-def scale_img(image, scaling_factor, upscale=False, input_type="img", plot_result=False):
+def scale_img(image, scaling_factor, upscale=False, input_type="img", plot_result=False, use_gaussian_scaling=False):
     """
     Downscale an image by averaging over non-overlapping blocks of the specified size.
     OR Upscale by repeating the pixels.
@@ -196,10 +196,12 @@ def scale_img(image, scaling_factor, upscale=False, input_type="img", plot_resul
 
     # IMAGES
     if input_type == 'img':
-        # NEW: By block-mean
-        return scale_with_block_mean(image, scaling_factor)
-        # OLD: by gaussian filter and striding
-        return scale_with_gaussian(image, scaling_factor, plot_blurred=plot_result)
+        if not use_gaussian_scaling:
+            # NEW: By block-mean
+            return scale_with_block_mean(image, scaling_factor)
+        else:
+            # OLD: by gaussian filter and striding
+            return scale_with_gaussian(image, scaling_factor, plot_blurred=plot_result)
 
     # For LABELS and COORDINATES, we slice/stack the image to apply the downscaling along new axes
     # First, we pad to the next multiple of the scaling factor, distributing on each side (with 1 pixel more on bottom/right if uneven)

--- a/src/napari_convpaint/utils.py
+++ b/src/napari_convpaint/utils.py
@@ -153,7 +153,7 @@ def guided_model_download(model_file: str, model_url: str, model_dir: str = None
 
 ### SCALING AND RESCALING
 
-def scale_img(image, scaling_factor, upscale=False, input_type="img"):
+def scale_img(image, scaling_factor, upscale=False, input_type="img", plot_result=False):
     """
     Downscale an image by averaging over non-overlapping blocks of the specified size.
     OR Upscale by repeating the pixels.
@@ -169,6 +169,8 @@ def scale_img(image, scaling_factor, upscale=False, input_type="img"):
     input_type : str ("img", "labels", "coords")
         Type of the input image. Determines how to scale the image:
         If "img", use median, if "labels", use mode, if "coords", use max.
+    plot_result : bool
+        If True, plot the original and scaled images.
 
     Returns:
     ----------
@@ -197,7 +199,7 @@ def scale_img(image, scaling_factor, upscale=False, input_type="img"):
         # NEW: By block-mean
         return scale_with_block_mean(image, scaling_factor)
         # OLD: by gaussian filter and striding
-        return scale_with_gaussian(image, scaling_factor)
+        return scale_with_gaussian(image, scaling_factor, plot_blurred=plot_result)
 
     # For LABELS and COORDINATES, we slice/stack the image to apply the downscaling along new axes
     # First, we pad to the next multiple of the scaling factor, distributing on each side (with 1 pixel more on bottom/right if uneven)
@@ -246,11 +248,13 @@ def scale_img(image, scaling_factor, upscale=False, input_type="img"):
         if len(classes_before) != len(classes_after):
             warnings.warn(f"Classes have changed after downscaling from {classes_before} to {classes_after}.")
 
-        # from matplotlib import pyplot as plt
-        # fig, ax = plt.subplots(1, 2, figsize=(10, 5))
-        # ax[0].imshow(image[0,...], cmap='gray')
-        # ax[1].imshow(scaled_img[0,...], cmap='gray')
-        # plt.show()
+        if plot_result:
+            from matplotlib import pyplot as plt
+            _, ax = plt.subplots(1, 2, figsize=(10, 5))
+            ax[0].imshow(image[0,...], cmap='gray')
+            ax[1].imshow(scaled_img[0,...], cmap='gray')
+            plt.show()
+        
         return scaled_img
 
     elif input_type == 'coords':
@@ -291,7 +295,7 @@ def scale_with_block_mean(image, scaling_factor):
     block_shape = (1,) * (image.ndim - 2) + (scaling_factor, scaling_factor)
     return block_reduce(image, block_size=block_shape, func=np.mean)
 
-def scale_with_gaussian(image, scaling_factor):
+def scale_with_gaussian(image, scaling_factor, plot_blurred=False):
     # Apply a small Gaussian blur to avoid aliasing
     sigma = 0.4 * scaling_factor
     sigma = [0] * (image.ndim - 2) + [sigma, sigma]  # Add zeros for batch and channel dimensions
@@ -301,12 +305,15 @@ def scale_with_gaussian(image, scaling_factor):
     start_h = (H % scaling_factor) // 2 # Move the start such that the image is centered
     start_w = (W % scaling_factor) // 2 # Move the start such that the image is centered
     scaled_img = blurred_img[..., start_h::scaling_factor, start_w::scaling_factor]
-    # from matplotlib import pyplot as plt
-    # fig, ax = plt.subplots(1, 3, figsize=(15, 5))
-    # ax[0].imshow(image[0,0,...], cmap='gray')
-    # ax[1].imshow(blurred_img[0,0,...], cmap='gray')
-    # ax[2].imshow(scaled_img[0,0,...], cmap='gray')
-    # plt.show()
+
+    if plot_blurred:
+        from matplotlib import pyplot as plt
+        _, ax = plt.subplots(1, 3, figsize=(15, 5))
+        ax[0].imshow(image[0,0,...], cmap='gray')
+        ax[1].imshow(blurred_img[0,0,...], cmap='gray')
+        ax[2].imshow(scaled_img[0,0,...], cmap='gray')
+        plt.show()
+    
     return scaled_img
 
 def fast_mode(arr, axis):
@@ -516,11 +523,9 @@ def pad_to_shape(feat, target_shape):
         pad.append((pad_before, pad_after))
     return np.pad(feat, pad, mode='constant')
 
-
 def align_up(val, alignment):
     """Smallest multiple of `alignment` that is >= `val`. Alignment must be >= 1."""
     return ((val + alignment - 1) // alignment) * alignment
-
 
 def crop_to_shape(arr, target_shape, crop_top=None, crop_left=None):
     """
@@ -570,7 +575,6 @@ def crop_to_shape(arr, target_shape, crop_top=None, crop_left=None):
     w_end = -crop_right if crop_right > 0 else None
 
     return arr[..., crop_top:h_end, crop_left:w_end]
-
 
 def get_annot_planes(img, annot=None, coords=None):
     """

--- a/src/napari_convpaint/utils.py
+++ b/src/napari_convpaint/utils.py
@@ -195,16 +195,12 @@ def scale_img(image, scaling_factor, upscale=False, input_type="img", plot_resul
     # Else DOWNSCALE the image
 
     # IMAGES
-    if input_type == 'img':
-        if not use_gaussian_scaling:
-            # NEW: By block-mean
-            return scale_with_block_mean(image, scaling_factor)
-        else:
-            # OLD: by gaussian filter and striding
-            return scale_with_gaussian(image, scaling_factor, plot_blurred=plot_result)
+    if input_type in ('img', 'image') and use_gaussian_scaling:
+        # OLD: by gaussian filter and striding
+        return scale_with_gaussian(image, scaling_factor, plot_blurred=plot_result)
 
-    # For LABELS and COORDINATES, we slice/stack the image to apply the downscaling along new axes
-    # First, we pad to the next multiple of the scaling factor, distributing on each side (with 1 pixel more on bottom/right if uneven)
+    # For IMAGE WITH BLOCK_REDUCE, LABELS and COORDINATES, we pad to the next multiple of the scaling factor,
+    # distributing on each side (with 1 pixel more on bottom/right if uneven)
     if image.shape[-2] % scaling_factor != 0 or image.shape[-1] % scaling_factor != 0:
         # Calculate padding sizes
         pad_h = (scaling_factor - (image.shape[-2] % scaling_factor)) % scaling_factor
@@ -213,7 +209,12 @@ def scale_img(image, scaling_factor, upscale=False, input_type="img", plot_resul
         pad_bot, pad_right = pad_h - pad_top, pad_w - pad_left
         # Pad the image
         image = pad(image, (pad_top, pad_bot, pad_left, pad_right), input_type=input_type)
-    # Slice the last two dimensions
+
+    if input_type in ('img', 'image'):
+        # For images, use block_reduce with mean
+        return scale_with_block_mean(image, scaling_factor)
+
+    # For LABELS and COORDINATES, slice the last two dimensions
     slice_start = (0, 0) #((image.shape[-2] % scaling_factor) // 2,
                     #  (image.shape[-1] % scaling_factor) // 2)
     slice_size = (image.shape[-2] // scaling_factor * scaling_factor, # These should now be equal to image shape, since we padded ...
@@ -286,8 +287,8 @@ def scale_with_block_mean(image, scaling_factor):
     image = np.asarray(image)
     H, W = image.shape[-2:]
     # Centre-crop to a multiple of `scaling_factor` (matches the prior
-    # centring behaviour). In convpaint's pipeline `_get_overall_paddings`
-    # already pads to a multiple of all scalings, so this is normally a no-op.
+    # centring behaviour). In convpaint's context images already get padded to
+    # a multiple the all scaling factor, so this is normally a no-op.
     crop_h = H % scaling_factor
     crop_w = W % scaling_factor
     if crop_h or crop_w:


### PR DESCRIPTION
Add **new tiling policy** that allow to get same results with and without tiling. Fix small bugs encountered on the way...

- **Fix padding** with tiling: remove wrong "+1"
- Use **patch-multiple padding on top/left** to be on same grid as without tiling
- Define **NNs with patch** (for receptive filed; image dims shall be multiples of it)
- **Sort features** before passing to CLF; this is specifically to get same results with/without tiling and is debatable (can be easily turned off...)
- **Use block_mean** instead of gaussian+skipping
- Add _warn_if_global_context
- Add has_global_context to all FEs
- Use new _compute_nn_properties method in nnlayers
- Add tiling tests (test if results are same with vs without tiling)
- Widget: Fix and add dynamical, layer-dependent reading of tile_annotations from _has_global_context
- Fix regressed napari import names in guided_model_download
- (Add option to plot tiles when tiling for segmentation; helps checking tile sizes etc.)

NOTE: This PR is inspired by and **replaces PR #67** (which has a large amount of unnecessary/undesired code).