### PR TITLE
Fix regressed napari import names in guided_model_download

### DIFF
--- a/src/napari_convpaint/utils.py
+++ b/src/napari_convpaint/utils.py
@@ -97,8 +97,8 @@ def guided_model_download(model_file: str, model_url: str, model_dir: str = None
     # Try importing Napari tools
     use_napari = False
     try:
-        from napari.utils.progress import progress as napari_s
-        from napari.utils.notifications import show_info, shs
+        from napari.utils.progress import progress as napari_progress
+        from napari.utils.notifications import show_info, show_error
         import napari
         if napari.current_viewer():
             use_napari = True


### PR DESCRIPTION
A botched search/replace in 012a22a left the names `napari_s` and `shs` in the napari import block. ef22943 cleaned the placeholder text but not the names, so the imports raise ImportError, get swallowed, and `use_napari` stays False — the napari progress bar and error popup have been silently disabled since.

Restores the original `napari_progress` and `show_error` names.