### PR TITLE
Performance overhaul: feature cache, tiled/out-of-core prediction, correctness sweep

### DIFF
--- a/src/napari_convpaint/_tests/test_bugfix_regressions.py
+++ b/src/napari_convpaint/_tests/test_bugfix_regressions.py
@@ -82,17 +82,6 @@ def test_tiled_equals_whole_image_with_downsample():
     np.testing.assert_allclose(tiled, whole, rtol=0, atol=1e-4)
 
 
-def test_tiled_equals_whole_image_dask():
-    """Threaded dask tiling shares one model across tile threads; results must
-    match the sequential tiled pass (thread-local shape bookkeeping)."""
-    cp = _trained_gaussian()
-    cp.set_params(tile_image=True, ignore_warnings=True)
-    img = np.random.RandomState(3).rand(1400, 1400).astype(np.float32)
-    seq = cp._predict(img)
-    par = cp._predict(img, use_dask=True)
-    np.testing.assert_allclose(par, seq, rtol=0, atol=1e-5)
-
-
 def test_tile_block_math_covers_all_sizes():
     """The kept regions of the tile loop must partition the image exactly for
     any padding/scaling/downsample combination (incl. margin >= block size),

--- a/src/napari_convpaint/_tests/test_bugfix_regressions.py
+++ b/src/napari_convpaint/_tests/test_bugfix_regressions.py
@@ -1,0 +1,291 @@
+"""Regression tests for the bug-fix sweep on the performance branch.
+
+Each test pins one of the fixed bugs so it cannot silently return:
+tiling block math, downsample-aware tile alignment, feature-cache disk
+routing / spill opt-out / FE-state keys, legacy FE name mapping, the
+feature-semantics load warning, memory-mode img_ids alignment, chunked
+classifier prediction, and nnlayers empty-selection defaults.
+Uses the gaussian FE throughout (no weight downloads, fast)."""
+
+import os
+import pickle
+import tempfile
+import warnings
+
+import numpy as np
+import pytest
+
+from napari_convpaint import convpaint_model as cpm_mod
+from napari_convpaint.convpaint_model import ConvpaintModel
+from napari_convpaint.feature_cache import FeatureCache
+
+
+def _mb(n):
+    return np.zeros(int(n * 1024 * 1024), dtype=np.uint8)
+
+
+def _trained_gaussian(im_size=64, scalings=None):
+    cp = ConvpaintModel('gaussian')
+    if scalings is not None:
+        cp.set_params(fe_scalings=scalings, ignore_warnings=True)
+    img = np.random.RandomState(0).rand(1, im_size, im_size).astype(np.float32)
+    annot = np.zeros((1, im_size, im_size), dtype=np.uint8)
+    annot[0, :10, :10] = 1
+    annot[0, -10:, -10:] = 2
+    cp.train(img, annot)
+    return cp
+
+
+# --------------------------------------------------------------------------
+# Tiled prediction block math
+# --------------------------------------------------------------------------
+
+def test_tiled_predict_exact_multiple_no_extra_blocks():
+    """An image side that is an exact multiple of the block size must not
+    produce an extra (empty/wasted) tile per axis."""
+    cp = _trained_gaussian()
+    cp.set_params(tile_image=True, ignore_warnings=True)
+
+    calls = []
+    orig = cp._predict_image
+
+    def counting(image, **kwargs):
+        calls.append(np.asarray(image).shape)
+        return orig(image, **kwargs)
+
+    cp._predict_image = counting
+    # gaussian: alignment=1, block 1000 -> maxblock 1000; H=W=2000 exact multiple
+    img = np.random.RandomState(1).rand(2000, 2000).astype(np.float32)
+    probas = cp._predict(img)
+    assert len(calls) == 4, f"expected 2x2 tiles, got {len(calls)}: {calls}"
+    assert probas.shape[-2:] == (2000, 2000)
+    # No tile may be empty
+    assert all(s[-1] > 0 and s[-2] > 0 for s in calls)
+
+
+def test_tiled_equals_whole_image_with_downsample():
+    """Auto-/forced tiling with image_downsample > 1 must produce the same
+    output as the whole-image pass (tile origins on the downsample grid)."""
+    cp = _trained_gaussian()
+    cp.set_params(image_downsample=3, ignore_warnings=True)
+    img = np.random.RandomState(2).rand(1602, 1602).astype(np.float32)
+
+    cp.set_params(tile_image=True, ignore_warnings=True)
+    tiled = cp._predict(img)
+
+    cp.set_params(tile_image=False, ignore_warnings=True)
+    old_min_side = cpm_mod.AUTO_TILE_MIN_SIDE
+    cpm_mod.AUTO_TILE_MIN_SIDE = 10_000  # force the whole-image path
+    try:
+        whole = cp._predict(img)
+    finally:
+        cpm_mod.AUTO_TILE_MIN_SIDE = old_min_side
+
+    assert tiled.shape == whole.shape
+    # Tolerance sits above float32 accumulation noise (~1e-5, from computing
+    # the same gaussian on different-width arrays) but far below the ~0.3 (bad
+    # alignment) and ~0.02 (missing interpolation halo) seams this test pins.
+    np.testing.assert_allclose(tiled, whole, rtol=0, atol=1e-4)
+
+
+def test_tiled_equals_whole_image_dask():
+    """Threaded dask tiling shares one model across tile threads; results must
+    match the sequential tiled pass (thread-local shape bookkeeping)."""
+    cp = _trained_gaussian()
+    cp.set_params(tile_image=True, ignore_warnings=True)
+    img = np.random.RandomState(3).rand(1400, 1400).astype(np.float32)
+    seq = cp._predict(img)
+    par = cp._predict(img, use_dask=True)
+    np.testing.assert_allclose(par, seq, rtol=0, atol=1e-5)
+
+
+def test_tile_block_math_covers_all_sizes():
+    """The kept regions of the tile loop must partition the image exactly for
+    any margin/alignment combination (incl. margin >= block size)."""
+    def align_up(x, a):
+        return -(-x // a) * a
+
+    def check(H, block_size, alignment, fe_margin):
+        if fe_margin == 0:
+            fe_margin = 50
+        margin = align_up(fe_margin, alignment)
+        maxblock = max(alignment, (block_size // alignment) * alignment)
+        if maxblock <= margin:
+            maxblock = margin + alignment
+        n = -(-H // maxblock)
+        kept = []
+        for row in range(n):
+            min_row = max(0, row * maxblock - margin)
+            min_row_ind = 0 if min_row == 0 else min_row + margin
+            max_row_ind = min(min_row_ind + maxblock, H)
+            kept.append((min_row_ind, max_row_ind))
+        assert kept[0][0] == 0 and kept[-1][1] == H
+        assert all(a2 > a1 for a1, a2 in kept)
+        assert all(k1[1] == k2[0] for k1, k2 in zip(kept, kept[1:]))
+
+    for H in range(200, 4000, 137):
+        for alignment in (1, 2, 4, 8, 14, 16, 42, 84, 336):
+            for fe_margin in (0, 24, 50, 100, 400, 1040):
+                check(H, 1000, alignment, fe_margin)
+
+
+def test_fe_alignment_includes_downsample():
+    cp = ConvpaintModel('gaussian')
+    cp.set_params(fe_scalings=[1, 2], ignore_warnings=True)
+    base = cp._get_fe_alignment(cp._param)
+    cp.set_params(image_downsample=3, ignore_warnings=True)
+    assert cp._get_fe_alignment(cp._param) == base * 3
+    # Upscaling must not change the alignment
+    cp.set_params(image_downsample=-3, ignore_warnings=True)
+    assert cp._get_fe_alignment(cp._param) == base
+
+
+# --------------------------------------------------------------------------
+# Feature cache: storage tiers and keys
+# --------------------------------------------------------------------------
+
+def test_cache_oversized_payload_goes_to_disk():
+    c = FeatureCache(max_bytes=1024 * 1024, headroom_frac=0.0,
+                     disk_max_bytes=64 * 1024 * 1024)
+    try:
+        payload = _mb(2)  # 2 MB > 1 MB RAM cap
+        c.put(('big',), payload)
+        assert len(c) == 0
+        assert c.stats()['disk_entries'] == 1
+        got = c.get(('big',))
+        assert got is not None and got.nbytes == payload.nbytes
+    finally:
+        c.close()
+
+
+def test_cache_spill_ok_false_never_touches_disk():
+    c = FeatureCache(max_bytes=1024 * 1024, headroom_frac=0.0,
+                     disk_max_bytes=64 * 1024 * 1024)
+    try:
+        c.put(('a',), _mb(0.6), spill_ok=False)
+        c.put(('b',), _mb(0.6))  # evicts 'a' -> must be dropped, not spilled
+        assert c.stats()['disk_entries'] == 0
+        assert c.get(('a',)) is None
+        # An oversized no-spill payload is not cached anywhere
+        c.put(('huge',), _mb(2), spill_ok=False)
+        assert c.get(('huge',)) is None
+        assert c.stats()['disk_entries'] == 0
+    finally:
+        c.close()
+
+
+def test_hookmodel_opts_out_of_disk_spill():
+    from napari_convpaint.feature_extractor import FeatureExtractor
+    assert FeatureExtractor.cache_spill_to_disk(object()) is True
+    from napari_convpaint.feature_extractors.nnlayers import Hookmodel
+    assert Hookmodel.cache_spill_to_disk(object()) is False
+
+
+def test_cache_key_includes_gaussian_sigma():
+    cp = ConvpaintModel('gaussian')
+    sig_before = cp._fe_cache_signature(cp._param)
+    cp.fe_model.sigma = cp.fe_model.sigma + 1
+    sig_after = cp._fe_cache_signature(cp._param)
+    assert sig_before != sig_after
+
+
+def test_cache_key_includes_jafar_scalings_state():
+    """The signature must change when the FE reports different extra state
+    (the mechanism JAFAR uses for jafar_scalings)."""
+    cp = ConvpaintModel('gaussian')
+    sig1 = cp._fe_cache_signature(cp._param)
+    orig = cp.fe_model.cache_extra_state
+    cp.fe_model.cache_extra_state = lambda p: ('jafar_scalings', (1, 8))
+    try:
+        sig2 = cp._fe_cache_signature(cp._param)
+    finally:
+        cp.fe_model.cache_extra_state = orig
+    assert sig1 != sig2
+
+
+# --------------------------------------------------------------------------
+# Saved-model compatibility
+# --------------------------------------------------------------------------
+
+def test_legacy_names_map_to_registered_models():
+    if not ConvpaintModel.FE_MODELS_TYPES_DICT:
+        ConvpaintModel._init_fe_models_dict()
+    for old, new in cpm_mod.LEGACY_FE_NAMES.items():
+        assert old not in ConvpaintModel.FE_MODELS_TYPES_DICT
+        assert new in ConvpaintModel.FE_MODELS_TYPES_DICT, (old, new)
+    for old, new in cpm_mod.LEGACY_ALIASES.items():
+        assert old not in ConvpaintModel.STD_MODELS
+        assert new in ConvpaintModel.STD_MODELS, (old, new)
+
+
+def test_old_model_without_semantics_stamp_warns_on_load():
+    cp = _trained_gaussian(32)
+    with tempfile.TemporaryDirectory() as td:
+        path = os.path.join(td, 'model.pkl')
+        cp.save(os.path.join(td, 'model'), create_yml=False)
+        # Simulate a model saved by an older release: no feature_semantics
+        with open(path, 'rb') as f:
+            data = pickle.load(f)
+        data['param'].feature_semantics = None
+        with open(path, 'wb') as f:
+            pickle.dump(data, f)
+        with warnings.catch_warnings(record=True) as rec:
+            warnings.simplefilter('always')
+            ConvpaintModel(model_path=path)
+        assert any('feature computation' in str(w.message) for w in rec)
+        # A freshly saved model must NOT warn
+        cp.save(os.path.join(td, 'fresh'), create_yml=False)
+        with warnings.catch_warnings(record=True) as rec:
+            warnings.simplefilter('always')
+            ConvpaintModel(model_path=os.path.join(td, 'fresh.pkl'))
+        assert not any('feature computation' in str(w.message) for w in rec)
+
+
+# --------------------------------------------------------------------------
+# Memory-mode img_ids alignment
+# --------------------------------------------------------------------------
+
+def test_memory_mode_img_ids_follow_kept_images():
+    cp = ConvpaintModel('gaussian')
+    rng = np.random.RandomState(4)
+    img_a = rng.rand(1, 32, 32).astype(np.float32)
+    img_b = rng.rand(1, 32, 32).astype(np.float32)
+    empty = np.zeros((1, 32, 32), dtype=np.uint8)
+    annot_b = np.zeros((1, 32, 32), dtype=np.uint8)
+    annot_b[0, :8, :8] = 1
+    annot_b[0, -8:, -8:] = 2
+    out = cp._get_features([img_a, img_b], annotations=[empty, annot_b],
+                           restore_input_form=False, memory_mode=True,
+                           img_ids=['A', 'B'])
+    features, annots, coords, img_ids, scale = out
+    assert len(features) == len(img_ids)
+    assert set(img_ids) == {'B'}, f"ids misaligned: {img_ids}"
+
+
+# --------------------------------------------------------------------------
+# Chunked classifier prediction
+# --------------------------------------------------------------------------
+
+def test_clf_predict_chunked_matches_single_shot():
+    cp = _trained_gaussian(48)
+    feats = np.random.RandomState(5).rand(4, 1300, 900).astype(np.float32)
+    full = cp.classifier.predict_proba(
+        np.moveaxis(feats, 0, -1).reshape(-1, feats.shape[0]))
+    chunked = cp._clf_predict(feats, return_proba=True)
+    assert np.array_equal(np.moveaxis(full, -1, 0), chunked)
+
+
+# --------------------------------------------------------------------------
+# nnlayers empty-selection defaults
+# --------------------------------------------------------------------------
+
+def test_nnlayers_empty_selection_resets_properties():
+    pytest.importorskip('torchvision')
+    from napari_convpaint.feature_extractors.nnlayers import Hookmodel
+    fe = Hookmodel(model_name='vgg16')
+    assert fe.padding > 0
+    fe.selected_layers = []
+    fe._compute_nn_properties()
+    assert fe.padding == 0
+    assert fe.patch_size == 1
+    assert fe.has_global_context is False

--- a/src/napari_convpaint/_tests/test_bugfix_regressions.py
+++ b/src/napari_convpaint/_tests/test_bugfix_regressions.py
@@ -215,17 +215,6 @@ def test_cache_key_includes_jafar_scalings_state():
 # Saved-model compatibility
 # --------------------------------------------------------------------------
 
-def test_legacy_names_map_to_registered_models():
-    if not ConvpaintModel.FE_MODELS_TYPES_DICT:
-        ConvpaintModel._init_fe_models_dict()
-    for old, new in cpm_mod.LEGACY_FE_NAMES.items():
-        assert old not in ConvpaintModel.FE_MODELS_TYPES_DICT
-        assert new in ConvpaintModel.FE_MODELS_TYPES_DICT, (old, new)
-    for old, new in cpm_mod.LEGACY_ALIASES.items():
-        assert old not in ConvpaintModel.STD_MODELS
-        assert new in ConvpaintModel.STD_MODELS, (old, new)
-
-
 def test_old_model_without_semantics_stamp_warns_on_load():
     cp = _trained_gaussian(32)
     with tempfile.TemporaryDirectory() as td:

--- a/src/napari_convpaint/_tests/test_bugfix_regressions.py
+++ b/src/napari_convpaint/_tests/test_bugfix_regressions.py
@@ -2,15 +2,9 @@
 
 Each test pins one of the fixed bugs so it cannot silently return:
 tiling block math, downsample-aware tile alignment, feature-cache disk
-routing / spill opt-out / FE-state keys, legacy FE name mapping, the
-feature-semantics load warning, memory-mode img_ids alignment, chunked
-classifier prediction, and nnlayers empty-selection defaults.
-Uses the gaussian FE throughout (no weight downloads, fast)."""
-
-import os
-import pickle
-import tempfile
-import warnings
+routing / spill opt-out / FE-state cache keys, memory-mode img_ids
+alignment, chunked classifier prediction, and nnlayers empty-selection
+defaults. Uses the gaussian FE throughout (no weight downloads, fast)."""
 
 import numpy as np
 import pytest
@@ -209,33 +203,6 @@ def test_cache_key_includes_jafar_scalings_state():
     finally:
         cp.fe_model.cache_extra_state = orig
     assert sig1 != sig2
-
-
-# --------------------------------------------------------------------------
-# Saved-model compatibility
-# --------------------------------------------------------------------------
-
-def test_old_model_without_semantics_stamp_warns_on_load():
-    cp = _trained_gaussian(32)
-    with tempfile.TemporaryDirectory() as td:
-        path = os.path.join(td, 'model.pkl')
-        cp.save(os.path.join(td, 'model'), create_yml=False)
-        # Simulate a model saved by an older release: no feature_semantics
-        with open(path, 'rb') as f:
-            data = pickle.load(f)
-        data['param'].feature_semantics = None
-        with open(path, 'wb') as f:
-            pickle.dump(data, f)
-        with warnings.catch_warnings(record=True) as rec:
-            warnings.simplefilter('always')
-            ConvpaintModel(model_path=path)
-        assert any('feature computation' in str(w.message) for w in rec)
-        # A freshly saved model must NOT warn
-        cp.save(os.path.join(td, 'fresh'), create_yml=False)
-        with warnings.catch_warnings(record=True) as rec:
-            warnings.simplefilter('always')
-            ConvpaintModel(model_path=os.path.join(td, 'fresh.pkl'))
-        assert not any('feature computation' in str(w.message) for w in rec)
 
 
 # --------------------------------------------------------------------------

--- a/src/napari_convpaint/_tests/test_bugfix_regressions.py
+++ b/src/napari_convpaint/_tests/test_bugfix_regressions.py
@@ -101,32 +101,40 @@ def test_tiled_equals_whole_image_dask():
 
 def test_tile_block_math_covers_all_sizes():
     """The kept regions of the tile loop must partition the image exactly for
-    any margin/alignment combination (incl. margin >= block size)."""
-    def align_up(x, a):
-        return -(-x // a) * a
+    any padding/scaling/downsample combination (incl. margin >= block size),
+    using the REAL geometry code (_tile_geometry), not a copy of it."""
+    cp = ConvpaintModel('gaussian')
 
-    def check(H, block_size, alignment, fe_margin):
-        if fe_margin == 0:
-            fe_margin = 50
-        margin = align_up(fe_margin, alignment)
-        maxblock = max(alignment, (block_size // alignment) * alignment)
-        if maxblock <= margin:
-            maxblock = margin + alignment
-        n = -(-H // maxblock)
+    def check(H, padding, scalings, downsample):
+        cp.fe_model.padding = padding
+        cp.set_params(fe_scalings=scalings, image_downsample=downsample,
+                      ignore_warnings=True)
+        maxblock, margin, nrows, _ = cp._tile_geometry((H, H))
         kept = []
-        for row in range(n):
+        for row in range(nrows):
             min_row = max(0, row * maxblock - margin)
             min_row_ind = 0 if min_row == 0 else min_row + margin
             max_row_ind = min(min_row_ind + maxblock, H)
             kept.append((min_row_ind, max_row_ind))
-        assert kept[0][0] == 0 and kept[-1][1] == H
+        assert kept[0][0] == 0 and kept[-1][1] == H, (H, padding, scalings, downsample)
         assert all(a2 > a1 for a1, a2 in kept)
         assert all(k1[1] == k2[0] for k1, k2 in zip(kept, kept[1:]))
 
-    for H in range(200, 4000, 137):
-        for alignment in (1, 2, 4, 8, 14, 16, 42, 84, 336):
-            for fe_margin in (0, 24, 50, 100, 400, 1040):
-                check(H, 1000, alignment, fe_margin)
+    for H in range(200, 4000, 379):
+        for padding in (0, 12, 50, 130):
+            for scalings in ([1], [1, 2], [1, 2, 4, 8]):
+                for downsample in (1, 3, 7):
+                    check(H, padding, scalings, downsample)
+
+
+def test_tile_margin_floor_survives_downsample():
+    """Padding-0 FEs must keep (at least) the legacy 50px overlap even with
+    image_downsample > 1 — the fallback must apply before downsample scaling."""
+    cp = ConvpaintModel('gaussian')
+    cp.fe_model.padding = 0
+    cp.set_params(image_downsample=4, ignore_warnings=True)
+    _, margin, _, _ = cp._tile_geometry((2000, 2000))
+    assert margin >= 50 * 4, f"margin {margin} lost the 50px floor under downsampling"
 
 
 def test_fe_alignment_includes_downsample():

--- a/src/napari_convpaint/_tests/test_feature_cache.py
+++ b/src/napari_convpaint/_tests/test_feature_cache.py
@@ -126,3 +126,55 @@ def test_model_feature_cache_identical_and_reuses():
     assert np.array_equal(off2, on2)
     # cache actually stored and served something
     assert m_on._feature_cache.stats()["hits"] >= 1
+
+
+def test_disk_spillover_serves_ram_evicted_entries():
+    """RAM-evicted entries spill to disk and are served from there (bit-identical)."""
+    c = FeatureCache(max_bytes=int(2.5 * 10**6), headroom_frac=0.0,
+                     disk_max_bytes=100 * 10**6)
+    a = _arr(1); b = _arr(1); d = _arr(1)
+    c.put(("a",), a); c.put(("b",), b)  # RAM full (2 entries)
+    c.put(("c",), d)  # evicts "a" from RAM -> spills to disk
+    assert len(c) == 2 and c.stats()["disk_entries"] == 1
+    got = c.get(("a",))  # RAM miss -> disk hit
+    assert got is not None and np.array_equal(got, a)  # round-trips bit-identical
+    assert c.stats()["disk_hits"] == 1
+
+
+def test_disk_lru_eviction_and_total_miss():
+    c = FeatureCache(max_bytes=int(1.5 * 10**6), headroom_frac=0.0,
+                     disk_max_bytes=int(1.5 * 10**6))  # RAM holds 1, disk holds 1
+    c.put(("a",), _arr(1)); c.put(("b",), _arr(1))  # a -> disk, b in RAM
+    c.put(("c",), _arr(1))  # b -> disk (evicts a from disk), c in RAM
+    assert c.get(("a",)) is None      # a fell off disk entirely -> recompute
+    assert c.get(("b",)) is not None  # b on disk
+    assert c.get(("c",)) is not None  # c in RAM
+
+
+def test_disk_disabled_by_default():
+    c = FeatureCache(max_bytes=int(1.5 * 10**6), headroom_frac=0.0)  # no disk
+    c.put(("a",), _arr(1)); c.put(("b",), _arr(1))  # a evicted, dropped (no disk)
+    assert c.get(("a",)) is None and c.stats()["disk_entries"] == 0
+
+
+def test_clear_removes_disk_tier_and_tempdir():
+    import os
+    c = FeatureCache(max_bytes=int(1.5 * 10**6), headroom_frac=0.0,
+                     disk_max_bytes=100 * 10**6)
+    c.put(("a",), _arr(1)); c.put(("b",), _arr(1))  # a on disk
+    disk_dir = c._disk_dir
+    assert disk_dir is not None and os.path.isdir(disk_dir)
+    c.clear()
+    assert c.stats()["disk_entries"] == 0 and c.disk_nbytes == 0
+    c.close()
+    assert not os.path.isdir(disk_dir)  # temp dir removed
+
+
+def test_disk_bytes_never_exceeds_cap():
+    """Stress: many puts must never push the disk tier over its byte cap."""
+    cap = int(3.5 * 10**6)  # ~3 entries of 1 MB
+    c = FeatureCache(max_bytes=int(1.5 * 10**6), headroom_frac=0.0, disk_max_bytes=cap)
+    for i in range(20):
+        c.put((i,), _arr(1))
+        assert c.disk_nbytes <= cap  # invariant holds after every put
+    c.close()

--- a/src/napari_convpaint/_tests/test_feature_cache.py
+++ b/src/napari_convpaint/_tests/test_feature_cache.py
@@ -1,0 +1,128 @@
+"""Tests for the bounded feature cache (storage/eviction/budget logic)."""
+import numpy as np
+
+from napari_convpaint.feature_cache import FeatureCache
+
+
+def _arr(mb):
+    """A float32 array of approximately `mb` megabytes."""
+    n = int(mb * 1e6 / 4)
+    return np.zeros(n, dtype=np.float32)
+
+
+def test_hit_and_miss():
+    c = FeatureCache(max_bytes=100 * 10**6, headroom_frac=0.0)
+    assert c.get(("img", 0, "sig")) is None
+    payload = _arr(1)
+    c.put(("img", 0, "sig"), payload)
+    got = c.get(("img", 0, "sig"))
+    assert got is payload
+    assert c.stats()["hits"] == 1
+    assert c.stats()["misses"] == 1
+
+
+def test_lru_eviction_by_cap():
+    # Cap ~2.5 MB; each entry ~1 MB -> at most 2 fit, oldest evicted.
+    c = FeatureCache(max_bytes=int(2.5 * 10**6), headroom_frac=0.0)
+    c.put(("a",), _arr(1))
+    c.put(("b",), _arr(1))
+    assert len(c) == 2
+    c.put(("c",), _arr(1))  # evicts "a" (LRU)
+    assert len(c) == 2
+    assert c.get(("a",)) is None
+    assert c.get(("b",)) is not None
+    assert c.get(("c",)) is not None
+
+
+def test_lru_touch_on_get_protects_entry():
+    c = FeatureCache(max_bytes=int(2.5 * 10**6), headroom_frac=0.0)
+    c.put(("a",), _arr(1))
+    c.put(("b",), _arr(1))
+    assert c.get(("a",)) is not None  # touch "a" -> now "b" is LRU
+    c.put(("c",), _arr(1))            # should evict "b", not "a"
+    assert c.get(("a",)) is not None
+    assert c.get(("b",)) is None
+
+
+def test_single_oversize_payload_is_not_cached():
+    c = FeatureCache(max_bytes=1 * 10**6, headroom_frac=0.0)
+    c.put(("big",), _arr(5))  # 5 MB into a 1 MB cap -> skipped, not cached
+    assert len(c) == 0
+    assert c.get(("big",)) is None
+
+
+def test_overwrite_updates_size():
+    c = FeatureCache(max_bytes=100 * 10**6, headroom_frac=0.0)
+    c.put(("k",), _arr(1))
+    b0 = c.nbytes
+    c.put(("k",), _arr(3))  # replace with a bigger payload
+    assert c.nbytes > b0
+    assert len(c) == 1
+
+
+def test_invalidate_predicate():
+    c = FeatureCache(max_bytes=100 * 10**6, headroom_frac=0.0)
+    c.put(("imgA", 0, "sig"), _arr(1))
+    c.put(("imgA", 1, "sig"), _arr(1))
+    c.put(("imgB", 0, "sig"), _arr(1))
+    c.invalidate(lambda key: key[0] == "imgA")  # drop all imgA slices
+    assert c.get(("imgA", 0, "sig")) is None
+    assert c.get(("imgA", 1, "sig")) is None
+    assert c.get(("imgB", 0, "sig")) is not None
+    assert len(c) == 1
+
+
+def test_clear():
+    c = FeatureCache(max_bytes=100 * 10**6, headroom_frac=0.0)
+    c.put(("a",), _arr(1))
+    c.put(("b",), _arr(1))
+    c.clear()
+    assert len(c) == 0
+    assert c.nbytes == 0
+
+
+def test_disabled_cache_is_noop():
+    c = FeatureCache(max_bytes=100 * 10**6, headroom_frac=0.0, enabled=False)
+    c.put(("a",), _arr(1))
+    assert c.get(("a",)) is None
+    assert len(c) == 0
+
+
+def test_list_payload_size_accounted():
+    c = FeatureCache(max_bytes=int(2.5 * 10**6), headroom_frac=0.0)
+    c.put(("a",), [_arr(1), _arr(1)])  # ~2 MB as a list of arrays
+    assert len(c) == 1
+    c.put(("b",), _arr(1))  # pushes over 2.5 MB -> evicts "a"
+    assert c.get(("a",)) is None
+
+
+def test_model_feature_cache_identical_and_reuses():
+    """With the cache on, a re-extraction of the same image reuses features and
+    produces bit-identical output vs the cache off."""
+    import warnings
+    from napari_convpaint.convpaint_model import ConvpaintModel
+
+    rng = np.random.default_rng(0)
+    img = rng.random((64, 64), dtype=np.float32)
+    annot = np.zeros((64, 64), dtype=np.uint8)
+    annot[10:20, 10:20] = 1
+    annot[40:50, 40:50] = 2
+
+    def run(enable):
+        m = ConvpaintModel(fe_name="gaussian_features")
+        m.set_params(channel_mode="single")
+        if enable:
+            m.enable_feature_cache(True)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            m.train(img, annot)
+            seg1 = np.asarray(m.segment(img))
+            seg2 = np.asarray(m.segment(img))
+        return m, seg1, seg2
+
+    m_off, off1, off2 = run(False)
+    m_on, on1, on2 = run(True)
+    assert np.array_equal(off1, on1)
+    assert np.array_equal(off2, on2)
+    # cache actually stored and served something
+    assert m_on._feature_cache.stats()["hits"] >= 1

--- a/src/napari_convpaint/_tests/test_utils.py
+++ b/src/napari_convpaint/_tests/test_utils.py
@@ -72,3 +72,35 @@ def test_scale_img_image_and_labels_shape_match(factor, H, W, upscale):
         f"shape mismatch at factor={factor}, upscale={upscale}, (H,W)=({H},{W}): "
         f"img={img_out.shape[-2:]}  lbl={lbl_out.shape[-2:]}"
     )
+
+
+def test_imagenet_norm_uint8_unchanged():
+    """uint8 RGB is scaled by /255 then ImageNet stats — z-scored range."""
+    from napari_convpaint.utils import normalize_image_imagenet
+    rng = np.random.default_rng(0)
+    img = rng.integers(0, 256, (3, 1, 32, 32)).astype(np.uint8)
+    out = normalize_image_imagenet(img)
+    assert out.dtype == np.float32
+    assert out.min() < -1.0 and out.max() > 1.0  # ImageNet z-scored
+
+
+def test_imagenet_norm_float_in_unit_range_applied():
+    """A float image already in [0,1] gets ImageNet stats (not skipped)."""
+    from napari_convpaint.utils import normalize_image_imagenet
+    rng = np.random.default_rng(0)
+    img = rng.random((3, 1, 32, 32)).astype(np.float32)
+    out = normalize_image_imagenet(img)
+    assert not np.array_equal(out, img)  # normalization was applied
+    assert out.min() < 0.0  # mean-subtracted
+
+
+def test_imagenet_norm_float_out_of_range_rescaled_not_skipped():
+    """A float image outside [0,1] (e.g. microscopy) is percentile-rescaled to
+    [0,1] and ImageNet-normalized, rather than silently returned unchanged."""
+    from napari_convpaint.utils import normalize_image_imagenet
+    rng = np.random.default_rng(0)
+    img = rng.uniform(0, 4095, (3, 1, 32, 32)).astype(np.float32)
+    with pytest.warns(UserWarning, match="percentile rescale"):
+        out = normalize_image_imagenet(img)
+    assert not np.array_equal(out, img)          # NOT returned raw
+    assert out.min() < -1.0 and out.max() > 1.0  # ImageNet z-scored range

--- a/src/napari_convpaint/convpaint_model.py
+++ b/src/napari_convpaint/convpaint_model.py
@@ -119,7 +119,7 @@ class ConvpaintModel:
         'fe_order': list(range(0, 6)), # from 0 (nearest) to 5
     }
 
-    def __init__(self, alias=None, model_path=None, param=None, fe_name=None, **kwargs):
+    def __init__(self, alias=None, model_path=None, param=None, fe_name=None, _fe_model=None, **kwargs):
         """
         **Initializes a Convpaint model**. This can be done with an alias, a model path, a param object, or a feature extractor name.
         If initialized by FE name, also other parameters can be given to override the defaults of the FE model.
@@ -228,7 +228,7 @@ class ConvpaintModel:
         if model_path is not None:
             self._load(model_path)
         elif param is not None:
-            self._load_param(param)
+            self._load_param(param, fe_model=_fe_model)
         elif fe_name is not None:
             fe_layers = kwargs.pop('fe_layers', None)
             self._set_fe(fe_name, fe_layers)
@@ -617,12 +617,14 @@ class ConvpaintModel:
         self._set_fe(new_param.fe_name, new_param.fe_layers)
         self._param = new_param
 
-    def _load_param(self, param: Param):
+    def _load_param(self, param: Param, fe_model=None):
         """
         Loads the given param object into the model and sets the model accordingly.
         Only intended for internal use at model initiation.
+        `fe_model` optionally injects an already-constructed FeatureExtractor
+        matching param.fe_name/fe_layers, to avoid loading model weights twice.
         """
-        self._set_fe(param.fe_name, param.fe_layers)
+        self._set_fe(param.fe_name, param.fe_layers, fe_model=fe_model)
         self._param = self.get_fe_defaults()
         self.set_params(ignore_warnings=True, **param.__dict__) # Overwrite the parameters with the given parameters
 
@@ -666,11 +668,14 @@ class ConvpaintModel:
 
 
 ### FE METHODS
-    def _set_fe(self, fe_name=None, fe_layers=None):
+    def _set_fe(self, fe_name=None, fe_layers=None, fe_model=None):
         """
         Sets the FE model based on the given FE parameters.
         Creates new feature extractor, and resets the classifier.
         Only intended for internal use at model initiation.
+        `fe_model` optionally provides an already-constructed FeatureExtractor
+        for exactly these fe_name/fe_layers (heavy FEs load weights on
+        construction — reusing an instance avoids a second load).
         """
         # Lazy-import catboost here (before torch loads model weights) to avoid
         # a segfault on Apple Silicon caused by catboost initialising shared

--- a/src/napari_convpaint/convpaint_model.py
+++ b/src/napari_convpaint/convpaint_model.py
@@ -1004,7 +1004,63 @@ class ConvpaintModel:
             )
 
         return features
-    
+
+### FEATURE CACHE (optional; speeds the interactive annotate->predict loop)
+
+    def enable_feature_cache(self, enabled=True, max_bytes=None):
+        """Turn on whole-image feature caching. When on, the (resolution-
+        independent) native features of an extracted image are cached and reused
+        the next time the *same* image is processed with the same FE settings —
+        e.g. re-segmenting while refining scribbles, or the train->predict of one
+        image — instead of recomputing them. Cache entries are content-addressed
+        (a hash of the prepared image), so it is self-invalidating: a changed
+        image simply misses. Bounded by a memory budget (see FeatureCache), so it
+        is safe on stacks/movies. Off by default (opt-in)."""
+        from .feature_cache import FeatureCache
+        self._feature_cache = FeatureCache(max_bytes=max_bytes, enabled=enabled)
+        return self._feature_cache
+
+    def _fe_cache_signature(self, param):
+        """The FE-relevant part of the cache key: parameters whose change
+        invalidates extracted features (reusing the model's own train-reset set),
+        plus image_downsample and the FE's patch size."""
+        def _hashable(v):
+            # fe_scalings / fe_layers are lists -> make them hashable for the key.
+            if isinstance(v, list):
+                return tuple(_hashable(x) for x in v)
+            return v
+        keys = getattr(self, "_params_to_reset_training", [])
+        sig = tuple((k, _hashable(getattr(param, k, None))) for k in keys)
+        return sig + (("image_downsample", getattr(param, "image_downsample", 1)),
+                      ("patch_size", self.fe_model.get_patch_size()))
+
+    @staticmethod
+    def _data_hash(d):
+        """Content hash of a prepared image tile, so train/predict of the same
+        pixels share a cache entry without threading an id through the pipeline."""
+        import hashlib
+        arr = np.ascontiguousarray(d)
+        h = hashlib.blake2b(arr.view(np.uint8), digest_size=16)
+        h.update(str(arr.shape).encode())
+        h.update(str(arr.dtype).encode())
+        return h.hexdigest()
+
+    def _extract_pyramid_cached(self, d, param, keep_patched, device):
+        """Extract the feature pyramid for one image, consulting the feature
+        cache. Behaviour with the cache disabled (the default) is exactly
+        extract_features_pyramid; enabled, it caches/reuses the native features
+        (bit-identical output, since the pyramid split is exact)."""
+        cache = getattr(self, "_feature_cache", None)
+        fe = self.fe_model
+        if cache is None or not cache.enabled or not fe.supports_feature_cache(param):
+            return fe.extract_features_pyramid(d, param, patched=keep_patched, device=device)
+        key = (self._data_hash(d), self._fe_cache_signature(param))
+        payload = cache.get(key)
+        if payload is None:
+            payload = fe.cacheable_repr(d, param, device)
+            cache.put(key, payload, fe.cacheable_nbytes(payload))
+        return fe.features_from_cacheable(payload, d.shape, param, patched=keep_patched)
+
 ### BACKEND METHOD FOR FEATURE EXTRACTION
 
     def _get_features(self, data, annotations=None, restore_input_form=True,
@@ -1229,13 +1285,10 @@ class ConvpaintModel:
             supported_devices=self.fe_model.supported_devices(),
             warn=True,
         )
-        features = [self.fe_model.extract_features_pyramid(
-                d,
-                params_for_extract,
-                patched=keep_patched,
-                device=fe_runtime_device)
+        features = [self._extract_pyramid_cached(
+                d, params_for_extract, keep_patched, fe_runtime_device)
                     for d in data]
-        
+
         if pca_components:
             features = [utils.apply_pca_to_f_image(f, n_components=pca_components)
                         for f in features]

--- a/src/napari_convpaint/convpaint_model.py
+++ b/src/napari_convpaint/convpaint_model.py
@@ -1146,6 +1146,18 @@ class ConvpaintModel:
 
 ### PER-CALL SHAPE BOOKKEEPING (thread-local, see __init__)
 
+    def __getstate__(self):
+        # threading.local cannot be pickled, and dask serializes the model when
+        # tiles are submitted (even on a threaded cluster). Per-call shape state
+        # never needs to survive pickling — drop it and recreate on unpickle.
+        state = self.__dict__.copy()
+        state.pop('_shape_tls', None)
+        return state
+
+    def __setstate__(self, state):
+        self.__dict__.update(state)
+        self._shape_tls = threading.local()
+
     @property
     def original_shapes(self):
         return getattr(self._shape_tls, "original_shapes", None)

--- a/src/napari_convpaint/convpaint_model.py
+++ b/src/napari_convpaint/convpaint_model.py
@@ -1190,12 +1190,16 @@ class ConvpaintModel:
             if num_new == 0:
                 warnings.warn("No new annotations. Train with existing features.")
                 return [], [], [], [], params_for_extract.image_downsample
-            # Filter out the data where annots are totally empty
+            # Filter out the data where annots are totally empty (one keep-mask
+            # for data, ids and annotations — filtering img_ids against the
+            # already-filtered annotations would just truncate the list and
+            # misalign ids with images).
             else:
-                data = [d for d, ann in zip(data, annotations) if np.sum(ann > 0) > 0]
-                annotations = [ann for ann in annotations if np.sum(ann > 0) > 0]
+                keep = [np.sum(ann > 0) > 0 for ann in annotations]
+                data = [d for d, k in zip(data, keep) if k]
                 if img_ids is not None:
-                    img_ids = [img_id for img_id, ann in zip(img_ids, annotations) if np.sum(ann > 0) > 0]
+                    img_ids = [img_id for img_id, k in zip(img_ids, keep) if k]
+                annotations = [ann for ann, k in zip(annotations, keep) if k]
             coords = [utils.get_coordinates_image(d) for d in data]
         else:
             coords = [None for _ in data]  # No coordinates if not in memory mode

--- a/src/napari_convpaint/convpaint_model.py
+++ b/src/napari_convpaint/convpaint_model.py
@@ -1907,7 +1907,7 @@ class ConvpaintModel:
             return pred_reshaped[0]
         return pred_reshaped
 
-    def _parallel_predict_image(self, image, return_proba=True, use_dask=False, fe_use_device=None, plot_tiles=False, out=None):
+    def _parallel_predict_image(self, image, return_proba=True, use_dask=False, fe_use_device=None, out=None):
         """
         Backend method to predict an image using tiling and parallelization.
         Returns the class probabilities and optionally the segmentation of the images.
@@ -1937,12 +1937,26 @@ class ConvpaintModel:
         # tile_annot without alignment).
         fe_block_size = self.fe_model.get_tile_block_size()
         block_size = fe_block_size if fe_block_size is not None else DEFAULT_TARGET_TILE_BLOCK
-        alignment = self._get_fe_alignment(self._param) # scalings_lcm * fe_patch
+        alignment = self._get_fe_alignment(self._param) # scalings_lcm * fe_patch (* downsample)
         fe_margin = self.fe_model.get_padding() * int(np.max(self._param.fe_scalings))
+        if fe_margin == 0:
+            # FEs that declare no receptive-field padding (patch/global-context
+            # FEs like ViTs or cellpose) still produce features that depend on
+            # the surrounding tile content — keep the legacy 50 px overlap so
+            # tile boundaries are blended rather than hard seams.
+            fe_margin = 50
         margin = utils.align_up(fe_margin, alignment)
         maxblock = max(alignment, (block_size // alignment) * alignment)
-        nblocks_rows = image.shape[-2] // maxblock
-        nblocks_cols = image.shape[-1] // maxblock
+        # The kept-region bookkeeping below requires maxblock > margin (each
+        # tile's kept block must start beyond the previous tile's margin);
+        # grow the block for extreme margins (deep CNN layers at large
+        # scalings), otherwise blocks would duplicate/skip rows.
+        if maxblock <= margin:
+            maxblock = margin + alignment
+        # Ceil division: the last (partial) block covers the remainder; an exact
+        # multiple must NOT add an extra empty block (it would reach the FE).
+        nblocks_rows = -(-image.shape[-2] // maxblock)
+        nblocks_cols = -(-image.shape[-1] // maxblock)
 
         image = self._prep_dims_single(image)[0] # NOTE: should technically not be necessary, as done outside
 
@@ -1989,11 +2003,8 @@ class ConvpaintModel:
         new_min_col_ind_collection = []
         new_min_row_ind_collection = []
 
-        if plot_tiles:
-            img_to_plot = image.copy()
-
-        for row in range(nblocks_rows+1):
-            for col in range(nblocks_cols+1):
+        for row in range(nblocks_rows):
+            for col in range(nblocks_cols):
                 min_row = np.max([0, row*maxblock-margin])
                 min_col = np.max([0, col*maxblock-margin])
                 max_row = np.min([image.shape[-2], (row+1)*maxblock+margin])
@@ -2025,18 +2036,6 @@ class ConvpaintModel:
                 # image (np.memmap / zarr / dask) only loads the tile being
                 # processed rather than the whole image.
                 image_block = np.asarray(image[..., min_row:max_row, min_col:max_col])
-
-                # For plotting:
-                # Take the entire image, add boarders for the block
-                if plot_tiles:
-                    img_to_plot[..., min_row, min_col:max_col] = 1
-                    img_to_plot[..., max_row-1, min_col:max_col] = 1
-                    img_to_plot[..., min_row:max_row, min_col] = 1
-                    img_to_plot[..., min_row:max_row, max_col-1] = 1
-                    img_to_plot[..., min_row_ind, min_col_ind:max_col_ind] = 0.5
-                    img_to_plot[..., max_row_ind-1, min_col_ind:max_col_ind] = 0.5
-                    img_to_plot[..., min_row_ind:max_row_ind, min_col_ind] = 0.5
-                    img_to_plot[..., min_row_ind:max_row_ind, max_col_ind-1] = 0.5
 
                 # Predict the block using dask or directly (with no normalization, as it is done outside)
                 if use_dask:
@@ -2080,11 +2079,6 @@ class ConvpaintModel:
                     min_row_ind_collection[k]:max_row_ind_collection[k],
                     min_col_ind_collection[k]:max_col_ind_collection[k]] = crop_out
             client.close()
-
-        if plot_tiles:
-            from matplotlib import pyplot as plt
-            plt.imshow(img_to_plot[0, 0])
-            plt.show()
 
         return predicted_image_complete
 
@@ -2409,7 +2403,16 @@ class ConvpaintModel:
         fe_scalings = param.fe_scalings
         scalings_lcm = lcm(*fe_scalings)
         fe_patch  = self.fe_model.get_patch_size()
-        return scalings_lcm * fe_patch
+        alignment = scalings_lcm * fe_patch
+        # Tiles are cut in original pixel space but downsampled inside
+        # _get_features, so tile origins must also land on the downsample grid —
+        # otherwise the block-mean groups (and hence the features) of a tile are
+        # phase-shifted relative to the whole-image pass. Upscaling (negative
+        # image_downsample) keeps any aligned origin on the grid.
+        downsample = getattr(param, "image_downsample", 1)
+        if downsample and downsample > 1:
+            alignment *= downsample
+        return alignment
 
     def _get_overall_paddings(self, param, img_shape: Tuple[int, ...]):
         """

--- a/src/napari_convpaint/convpaint_model.py
+++ b/src/napari_convpaint/convpaint_model.py
@@ -40,6 +40,24 @@ TILE_ANNOT_MAX_BBOX_FRACTION = 0.5
 # block so at least a 2-block split happens.
 AUTO_TILE_MIN_SIDE = 1500
 
+# FE model names / aliases from earlier releases → their current equivalents,
+# so models saved (or scripts written) under the old names keep working.
+LEGACY_FE_NAMES = {
+    'dinov2_vits14_reg': 'dinov2_small-reg',
+    'dino_jafar_small': 'dinov2_small-reg_jafar',
+}
+LEGACY_ALIASES = {
+    'dino': 'dinov2',
+    'dino-jafar': 'dinov2-jafar',
+}
+
+# Version of the feature-computation semantics. Bump when a change alters the
+# numerical feature values (and therefore invalidates saved classifiers):
+#   1 (implicit) = pre-2026 releases (gaussian-blur+stride downscaling,
+#       out-of-range floats fed to imagenet normalization unmodified)
+#   2 = block-mean downscaling + percentile stretch of out-of-range floats
+FEATURE_SEMANTICS_VERSION = 2
+
 
 def _tiling_worthwhile(annot, whole_area):
     """Cheaply decide whether tiling around the annotations in `annot` is likely
@@ -200,6 +218,7 @@ class ConvpaintModel:
 
         # If an alias is given, create an corresponding model
         if alias is not None:
+            alias = LEGACY_ALIASES.get(alias, alias)
             if alias in ConvpaintModel.STD_MODELS:
                 param = ConvpaintModel.STD_MODELS[alias]
             else:
@@ -484,6 +503,9 @@ class ConvpaintModel:
         """
         if model_path[-4:] == ".pkl" or model_path[-4:] == ".yml":
             model_path = model_path[:-4]
+        # Stamp the feature semantics this model was trained under, so a later
+        # release whose feature computation changed can warn on load.
+        self._param.feature_semantics = FEATURE_SEMANTICS_VERSION
         if create_pkl:
             pkl_path = model_path + ".pkl"
             if self.classifier is None:
@@ -540,6 +562,17 @@ class ConvpaintModel:
         self._set_fe(new_param.fe_name, new_param.fe_layers)
         self._param = new_param.copy()
         self.classifier = data.get('classifier', None)
+        # A classifier trained under older feature semantics (different
+        # downscaling / normalization) will silently mis-predict on the current
+        # feature values — warn so the user knows to retrain.
+        if (self.classifier is not None and
+                getattr(new_param, 'feature_semantics', None) != FEATURE_SEMANTICS_VERSION):
+            warnings.warn(
+                f"This model was saved with an older Convpaint whose feature computation "
+                f"differed (multi-scale downscaling and normalization of out-of-range float "
+                f"images have changed). Its classifier may predict poorly on features computed "
+                f"by this version — consider retraining and re-saving the model."
+            )
         if self.classifier is None:
             self.num_features = 0
         else:
@@ -648,16 +681,23 @@ class ConvpaintModel:
         self.reset_classifier()
         self.reset_training()
 
+        # Remap FE names from earlier releases so the new name is also what
+        # gets stored in the param (and in future saves of this model).
+        fe_name = LEGACY_FE_NAMES.get(fe_name, fe_name)
+
         # Check if we need to create a new FE model
         fe_name_changed = fe_name != self._param.get("fe_name")
         fe_layers_changed = fe_layers != self._param.get("fe_layers")
 
         # Create the feature extractor model
         if fe_name_changed or fe_layers_changed:
-            self.fe_model = ConvpaintModel.create_fe(
-                name=fe_name,
-                layers=fe_layers
-            )
+            if fe_model is not None and fe_model.model_name == fe_name:
+                self.fe_model = fe_model
+            else:
+                self.fe_model = ConvpaintModel.create_fe(
+                    name=fe_name,
+                    layers=fe_layers
+                )
         
         # Set the parameters
         self._param.set(fe_name=fe_name, fe_layers=fe_layers)
@@ -687,6 +727,12 @@ class ConvpaintModel:
             The created feature extractor model
         """
         
+        # Remap FE names from earlier releases (e.g. saved models)
+        if name in LEGACY_FE_NAMES:
+            new_name = LEGACY_FE_NAMES[name]
+            warnings.warn(f"Feature extractor '{name}' was renamed to '{new_name}'; using the new name.")
+            name = new_name
+
         # Check if name is valid and create the feature extractor object
         if not name in ConvpaintModel.FE_MODELS_TYPES_DICT:
             raise ValueError(f'Feature extractor model {name} not found.')

--- a/src/napari_convpaint/convpaint_model.py
+++ b/src/napari_convpaint/convpaint_model.py
@@ -1,5 +1,4 @@
 import pickle
-import threading
 from pathlib import Path
 import importlib
 import inspect
@@ -145,11 +144,6 @@ class ConvpaintModel:
         self.num_features = 0
         self._fe_locked_device = None
         self._clf_locked_device = None
-        # Per-call shape bookkeeping written by _get_features and read back by
-        # _predict_image/_restore_shape. Thread-local because tiled prediction
-        # with use_dask runs tiles as threads sharing this one model instance
-        # (Client(processes=False)) — plain attributes would race across tiles.
-        self._shape_tls = threading.local()
         self._params_to_reset_training = ['channel_mode',
                                           'normalize',
                                         #   'image_downsample',
@@ -1102,52 +1096,6 @@ class ConvpaintModel:
                       spill_ok=fe.cache_spill_to_disk())
         return fe.features_from_cacheable(payload, d.shape, param, patched=keep_patched)
 
-### PER-CALL SHAPE BOOKKEEPING (thread-local, see __init__)
-
-    def __getstate__(self):
-        # threading.local cannot be pickled, and dask serializes the model when
-        # tiles are submitted (even on a threaded cluster). Per-call shape state
-        # never needs to survive pickling — drop it and recreate on unpickle.
-        state = self.__dict__.copy()
-        state.pop('_shape_tls', None)
-        return state
-
-    def __setstate__(self, state):
-        self.__dict__.update(state)
-        self._shape_tls = threading.local()
-
-    @property
-    def original_shapes(self):
-        return getattr(self._shape_tls, "original_shapes", None)
-
-    @original_shapes.setter
-    def original_shapes(self, value):
-        self._shape_tls.original_shapes = value
-
-    @property
-    def pre_pad_shapes(self):
-        return getattr(self._shape_tls, "pre_pad_shapes", None)
-
-    @pre_pad_shapes.setter
-    def pre_pad_shapes(self, value):
-        self._shape_tls.pre_pad_shapes = value
-
-    @property
-    def padded_shapes(self):
-        return getattr(self._shape_tls, "padded_shapes", None)
-
-    @padded_shapes.setter
-    def padded_shapes(self, value):
-        self._shape_tls.padded_shapes = value
-
-    @property
-    def paddings(self):
-        return getattr(self._shape_tls, "paddings", None)
-
-    @paddings.setter
-    def paddings(self, value):
-        self._shape_tls.paddings = value
-
 ### BACKEND METHOD FOR FEATURE EXTRACTION
 
     def _get_features(self, data, annotations=None, restore_input_form=True,
@@ -2017,20 +1965,12 @@ class ConvpaintModel:
         else:
             predicted_image_complete = np.zeros(expected_shape, dtype=expected_dtype)
 
-        # Prepare dask client if enabled.
-        # NOTE (perf): use a threaded, single-process cluster (processes=False).
-        # A process-based cluster (the previous Client()) pickles every submitted
-        # task's arguments to worker processes — and because we submit the bound
-        # method self._predict_image, that pickles the whole ConvpaintModel
-        # (including the FE's torch weights) once per tile, plus it spawns worker
-        # processes on every call. With threads the model is shared in-process
-        # (no serialization, valid on MPS/GPU) and torch/numpy/catboost release
-        # the GIL during compute, so tiles still overlap.
+        # Prepare dask client if enabled
         if use_dask:
             from dask.distributed import Client
             import dask
             dask.config.set({'distributed.worker.daemon': False})
-            client = Client(processes=False)
+            client = Client()
             processes = []
 
         # Iterate over the blocks of the image and predict each block separately

--- a/src/napari_convpaint/convpaint_model.py
+++ b/src/napari_convpaint/convpaint_model.py
@@ -1979,6 +1979,54 @@ class ConvpaintModel:
             return pred_reshaped[0]
         return pred_reshaped
 
+    def _tile_geometry(self, image_shape):
+        """Block size, margin and block counts for `_parallel_predict_image`.
+
+        Derives the per-tile margin from the FE's required padding at the
+        largest scaling, so every pixel in the kept region sees the same
+        receptive-field context as in whole-image processing. Both the block
+        size and the margin are snapped to the FE's alignment grid so tile
+        origins/sizes are multiples of it — otherwise the deeper feature maps
+        upsample at a slightly different ratio than the whole-image pass and
+        features drift relative to physical pixel positions.
+
+        Kept separate from the prediction loop so tests can pin the geometry
+        (coverage, no empty tiles) without running a feature extractor."""
+        fe_block_size = self.fe_model.get_tile_block_size()
+        block_size = fe_block_size if fe_block_size is not None else DEFAULT_TARGET_TILE_BLOCK
+        alignment = self._get_fe_alignment(self._param) # scalings_lcm * fe_patch (* downsample)
+        fe_margin = self.fe_model.get_padding() * int(np.max(self._param.fe_scalings))
+        if fe_margin == 0:
+            # FEs that declare no receptive-field padding (patch/global-context
+            # FEs like ViTs or cellpose) still produce features that depend on
+            # the surrounding tile content — keep the legacy 50 px overlap so
+            # tile boundaries are blended rather than hard seams.
+            # (Checked BEFORE the downsample scaling below, which would turn a
+            # zero margin into a tiny nonzero one and skip this fallback.)
+            fe_margin = 50
+        # The FE's receptive field applies in DOWNSAMPLED space, but the margin
+        # is cut in original pixel space — scale it by the downsample factor or
+        # tile-boundary pixels lose context and drift from the whole-image pass.
+        # The extra +1 downsampled pixel covers the interpolation halo of the
+        # order-1 upscale back to original resolution (_restore_shape step 4),
+        # which reads one neighbor beyond the kept region.
+        downsample = self._param.image_downsample or 1
+        if downsample > 1:
+            fe_margin = (fe_margin + 1) * downsample
+        margin = utils.align_up(fe_margin, alignment)
+        maxblock = max(alignment, (block_size // alignment) * alignment)
+        # The kept-region bookkeeping requires maxblock > margin (each tile's
+        # kept block must start beyond the previous tile's margin); grow the
+        # block for extreme margins (deep CNN layers at large scalings),
+        # otherwise blocks would duplicate/skip rows.
+        if maxblock <= margin:
+            maxblock = margin + alignment
+        # Ceil division: the last (partial) block covers the remainder; an exact
+        # multiple must NOT add an extra empty block (it would reach the FE).
+        nblocks_rows = -(-image_shape[-2] // maxblock)
+        nblocks_cols = -(-image_shape[-1] // maxblock)
+        return maxblock, margin, nblocks_rows, nblocks_cols
+
     def _parallel_predict_image(self, image, return_proba=True, use_dask=False, fe_use_device=None, out=None):
         """
         Backend method to predict an image using tiling and parallelization.
@@ -1999,45 +2047,7 @@ class ConvpaintModel:
         """
 
         self._warn_if_global_context("tile_image")
-        # Derive the per-tile margin from the FE's required padding at the largest
-        # scaling, so every pixel in the kept region sees the same receptive-field
-        # context it would see during whole-image processing. Snap both the block
-        # size and the margin to the FE's downsampling grid so tile origins and
-        # sizes are multiples of it — otherwise the deeper feature maps upsample
-        # at a slightly different ratio than the whole-image pass and features
-        # drift relative to physical pixel positions (same class of bug as
-        # tile_annot without alignment).
-        fe_block_size = self.fe_model.get_tile_block_size()
-        block_size = fe_block_size if fe_block_size is not None else DEFAULT_TARGET_TILE_BLOCK
-        alignment = self._get_fe_alignment(self._param) # scalings_lcm * fe_patch (* downsample)
-        fe_margin = self.fe_model.get_padding() * int(np.max(self._param.fe_scalings))
-        # The FE's receptive field applies in DOWNSAMPLED space, but the margin
-        # is cut in original pixel space — scale it by the downsample factor or
-        # tile-boundary pixels lose context and drift from the whole-image pass.
-        # The extra +1 downsampled pixel covers the interpolation halo of the
-        # order-1 upscale back to original resolution (_restore_shape step 4),
-        # which reads one neighbor beyond the kept region.
-        downsample = self._param.image_downsample or 1
-        if downsample > 1:
-            fe_margin = (fe_margin + 1) * downsample
-        if fe_margin == 0:
-            # FEs that declare no receptive-field padding (patch/global-context
-            # FEs like ViTs or cellpose) still produce features that depend on
-            # the surrounding tile content — keep the legacy 50 px overlap so
-            # tile boundaries are blended rather than hard seams.
-            fe_margin = 50
-        margin = utils.align_up(fe_margin, alignment)
-        maxblock = max(alignment, (block_size // alignment) * alignment)
-        # The kept-region bookkeeping below requires maxblock > margin (each
-        # tile's kept block must start beyond the previous tile's margin);
-        # grow the block for extreme margins (deep CNN layers at large
-        # scalings), otherwise blocks would duplicate/skip rows.
-        if maxblock <= margin:
-            maxblock = margin + alignment
-        # Ceil division: the last (partial) block covers the remainder; an exact
-        # multiple must NOT add an extra empty block (it would reach the FE).
-        nblocks_rows = -(-image.shape[-2] // maxblock)
-        nblocks_cols = -(-image.shape[-1] // maxblock)
+        maxblock, margin, nblocks_rows, nblocks_cols = self._tile_geometry(image.shape)
 
         image = self._prep_dims_single(image)[0] # NOTE: should technically not be necessary, as done outside
 

--- a/src/napari_convpaint/convpaint_model.py
+++ b/src/napari_convpaint/convpaint_model.py
@@ -553,6 +553,10 @@ class ConvpaintModel:
             data = safe_load(pkl_path)
             used_compat = True
         new_param = data.get('param', None)
+        # Remap legacy FE names on the loaded param itself (it replaces
+        # self._param below, so the remap in _set_fe alone would be lost).
+        if getattr(new_param, 'fe_name', None) in LEGACY_FE_NAMES:
+            new_param.fe_name = LEGACY_FE_NAMES[new_param.fe_name]
         # If there is the old use_gpu parameter saved, use lock_device to set the device policy for the feature extractor accordingly
         if hasattr(new_param, 'use_gpu'):
             device = 'gpu' if new_param.use_gpu else 'cpu'
@@ -614,6 +618,10 @@ class ConvpaintModel:
                 self.lock_device(device, part='both')
                 del params_to_set['use_gpu']
             new_param.set(**params_to_set)
+        # Remap legacy FE names on the loaded param itself (it replaces
+        # self._param below, so the remap in _set_fe alone would be lost).
+        if new_param.fe_name in LEGACY_FE_NAMES:
+            new_param.fe_name = LEGACY_FE_NAMES[new_param.fe_name]
         self._set_fe(new_param.fe_name, new_param.fe_layers)
         self._param = new_param
 
@@ -1086,8 +1094,9 @@ class ConvpaintModel:
         invalidates extracted features (reusing the model's own train-reset set),
         plus image_downsample and the FE's patch size."""
         def _hashable(v):
-            # fe_scalings / fe_layers are lists -> make them hashable for the key.
-            if isinstance(v, list):
+            # fe_scalings / fe_layers are lists (and FE extra state may nest
+            # lists in tuples) -> make them hashable for the key.
+            if isinstance(v, (list, tuple)):
                 return tuple(_hashable(x) for x in v)
             return v
         keys = getattr(self, "_params_to_reset_training", [])

--- a/src/napari_convpaint/convpaint_model.py
+++ b/src/napari_convpaint/convpaint_model.py
@@ -2002,6 +2002,15 @@ class ConvpaintModel:
         block_size = fe_block_size if fe_block_size is not None else DEFAULT_TARGET_TILE_BLOCK
         alignment = self._get_fe_alignment(self._param) # scalings_lcm * fe_patch (* downsample)
         fe_margin = self.fe_model.get_padding() * int(np.max(self._param.fe_scalings))
+        # The FE's receptive field applies in DOWNSAMPLED space, but the margin
+        # is cut in original pixel space — scale it by the downsample factor or
+        # tile-boundary pixels lose context and drift from the whole-image pass.
+        # The extra +1 downsampled pixel covers the interpolation halo of the
+        # order-1 upscale back to original resolution (_restore_shape step 4),
+        # which reads one neighbor beyond the kept region.
+        downsample = self._param.image_downsample or 1
+        if downsample > 1:
+            fe_margin = (fe_margin + 1) * downsample
         if fe_margin == 0:
             # FEs that declare no receptive-field padding (patch/global-context
             # FEs like ViTs or cellpose) still produce features that depend on

--- a/src/napari_convpaint/convpaint_model.py
+++ b/src/napari_convpaint/convpaint_model.py
@@ -1042,7 +1042,11 @@ class ConvpaintModel:
         keys = getattr(self, "_params_to_reset_training", [])
         sig = tuple((k, _hashable(getattr(param, k, None))) for k in keys)
         return sig + (("image_downsample", getattr(param, "image_downsample", 1)),
-                      ("patch_size", self.fe_model.get_patch_size()))
+                      ("patch_size", self.fe_model.get_patch_size()),
+                      # FE instance state outside the Param (e.g. jafar_scalings,
+                      # gaussian sigma) — without it, changing that state would
+                      # serve stale cached features.
+                      ("fe_extra", _hashable(self.fe_model.cache_extra_state(param))))
 
     @staticmethod
     def _data_hash(d):

--- a/src/napari_convpaint/convpaint_model.py
+++ b/src/napari_convpaint/convpaint_model.py
@@ -1007,17 +1007,21 @@ class ConvpaintModel:
 
 ### FEATURE CACHE (optional; speeds the interactive annotate->predict loop)
 
-    def enable_feature_cache(self, enabled=True, max_bytes=None):
+    def enable_feature_cache(self, enabled=True, max_bytes=None, disk_max_bytes=0):
         """Turn on whole-image feature caching. When on, the (resolution-
         independent) native features of an extracted image are cached and reused
         the next time the *same* image is processed with the same FE settings —
         e.g. re-segmenting while refining scribbles, or the train->predict of one
         image — instead of recomputing them. Cache entries are content-addressed
         (a hash of the prepared image), so it is self-invalidating: a changed
-        image simply misses. Bounded by a memory budget (see FeatureCache), so it
-        is safe on stacks/movies. Off by default (opt-in)."""
+        image simply misses. Bounded by a RAM budget (``max_bytes``); RAM-evicted
+        entries spill to disk up to ``disk_max_bytes`` (0 = off), which lets a
+        stack too large for RAM still benefit on the next iteration (loading a
+        cached slice from disk is much faster than recomputing it). Off by
+        default (opt-in)."""
         from .feature_cache import FeatureCache
-        self._feature_cache = FeatureCache(max_bytes=max_bytes, enabled=enabled)
+        self._feature_cache = FeatureCache(max_bytes=max_bytes, enabled=enabled,
+                                           disk_max_bytes=disk_max_bytes)
         return self._feature_cache
 
     def _fe_cache_signature(self, param):
@@ -1045,18 +1049,25 @@ class ConvpaintModel:
         h.update(str(arr.dtype).encode())
         return h.hexdigest()
 
-    def _extract_pyramid_cached(self, d, param, keep_patched, device):
+    def _extract_pyramid_cached(self, d, param, keep_patched, device, cache_only=False):
         """Extract the feature pyramid for one image, consulting the feature
         cache. Behaviour with the cache disabled (the default) is exactly
         extract_features_pyramid; enabled, it caches/reuses the native features
-        (bit-identical output, since the pyramid split is exact)."""
+        (bit-identical output, since the pyramid split is exact).
+
+        ``cache_only=True`` is a peek: return the reconstructed features only if
+        they are already cached, else return None WITHOUT running the (expensive)
+        feature extractor. This lets a stack prediction serve already-cached
+        slices first, before a sequential scan evicts them (see the widget)."""
         cache = getattr(self, "_feature_cache", None)
         fe = self.fe_model
         if cache is None or not cache.enabled or not fe.supports_feature_cache(param):
-            return fe.extract_features_pyramid(d, param, patched=keep_patched, device=device)
+            return None if cache_only else fe.extract_features_pyramid(d, param, patched=keep_patched, device=device)
         key = (self._data_hash(d), self._fe_cache_signature(param))
         payload = cache.get(key)
         if payload is None:
+            if cache_only:
+                return None
             payload = fe.cacheable_repr(d, param, device)
             cache.put(key, payload, fe.cacheable_nbytes(payload))
         return fe.features_from_cacheable(payload, d.shape, param, patched=keep_patched)
@@ -1066,7 +1077,7 @@ class ConvpaintModel:
     def _get_features(self, data, annotations=None, restore_input_form=True,
                           memory_mode=False, img_ids=None,
                           in_channels=None, skip_norm=False, use_device=None,
-                          pca_components=0, kmeans_clusters=0):
+                          pca_components=0, kmeans_clusters=0, cache_only=False):
         """
         Returns the features of images extracted by the feature extractor model.
 
@@ -1286,8 +1297,13 @@ class ConvpaintModel:
             warn=True,
         )
         features = [self._extract_pyramid_cached(
-                d, params_for_extract, keep_patched, fe_runtime_device)
+                d, params_for_extract, keep_patched, fe_runtime_device, cache_only=cache_only)
                     for d in data]
+
+        # cache_only peek: if any image's features are not already cached, signal
+        # a miss so the caller can defer this image to the compute pass.
+        if cache_only and any(f is None for f in features):
+            return None
 
         if pca_components:
             features = [utils.apply_pca_to_f_image(f, n_components=pca_components)
@@ -1674,7 +1690,7 @@ class ConvpaintModel:
 
         return features, annotations
 
-    def _predict(self, data, add_seg=False, in_channels=None, skip_norm=False, use_dask=False, fe_use_device=None):
+    def _predict(self, data, add_seg=False, in_channels=None, skip_norm=False, use_dask=False, fe_use_device=None, cache_only=False):
         """
         Backend method to predict images as a whole or tiling and parallelizing the prediction.
 
@@ -1711,7 +1727,19 @@ class ConvpaintModel:
         # but only for local-context FEs (a ViT's features depend on the whole
         # image). It is auto-enabled per image when the image is large enough to
         # actually be split; tile_image=True forces it regardless of size.
-        if self._param.tile_image:
+        if cache_only:
+            # Peek: only serve images whose features are already cached; return
+            # None on any miss so the caller defers it to the compute pass. The
+            # tiled path doesn't support the peek, so a tiled image counts as a
+            # miss (it is cheap/local anyway, where caching matters least).
+            probas = []
+            for d in data:
+                p = (None if (self._param.tile_image or self._should_auto_tile(d.shape))
+                     else self._predict_image(d, return_proba=True, fe_use_device=fe_use_device, cache_only=True))
+                if p is None:
+                    return None
+                probas.append(p)
+        elif self._param.tile_image:
             probas = [self._parallel_predict_image(d, return_proba=True, use_dask=use_dask, fe_use_device=fe_use_device)
                       for d in data]
         else:
@@ -1750,7 +1778,7 @@ class ConvpaintModel:
         h, w = image_shape[-2], image_shape[-1]
         return max(h, w) > AUTO_TILE_MIN_SIDE
 
-    def _predict_image(self, image, return_proba=True, feature_img=None, fe_use_device=None):
+    def _predict_image(self, image, return_proba=True, feature_img=None, fe_use_device=None, cache_only=False):
         """
         Backend method to predict images without tiling and parallelization.
         Returns the class probabilities and optionally the segmentation of the images.
@@ -1771,7 +1799,10 @@ class ConvpaintModel:
                                             restore_input_form=False,
                                             in_channels=None, # already extracted outside
                                             skip_norm=True, # already normalized outside
-                                            use_device=fe_use_device)
+                                            use_device=fe_use_device,
+                                            cache_only=cache_only)
+            if feature_img is None:  # cache_only peek: features not cached
+                return None
 
         num_f = feature_img[0].shape[0] if isinstance(feature_img, list) else feature_img.shape[0]
         num_f_clf = self.num_features

--- a/src/napari_convpaint/convpaint_model.py
+++ b/src/napari_convpaint/convpaint_model.py
@@ -40,13 +40,6 @@ TILE_ANNOT_MAX_BBOX_FRACTION = 0.5
 # block so at least a 2-block split happens.
 AUTO_TILE_MIN_SIDE = 1500
 
-# Version of the feature-computation semantics. Bump when a change alters the
-# numerical feature values (and therefore invalidates saved classifiers):
-#   1 (implicit) = pre-2026 releases (gaussian-blur+stride downscaling,
-#       out-of-range floats fed to imagenet normalization unmodified)
-#   2 = block-mean downscaling + percentile stretch of out-of-range floats
-FEATURE_SEMANTICS_VERSION = 2
-
 
 def _tiling_worthwhile(annot, whole_area):
     """Cheaply decide whether tiling around the annotations in `annot` is likely
@@ -491,9 +484,6 @@ class ConvpaintModel:
         """
         if model_path[-4:] == ".pkl" or model_path[-4:] == ".yml":
             model_path = model_path[:-4]
-        # Stamp the feature semantics this model was trained under, so a later
-        # release whose feature computation changed can warn on load.
-        self._param.feature_semantics = FEATURE_SEMANTICS_VERSION
         if create_pkl:
             pkl_path = model_path + ".pkl"
             if self.classifier is None:
@@ -550,17 +540,6 @@ class ConvpaintModel:
         self._set_fe(new_param.fe_name, new_param.fe_layers)
         self._param = new_param.copy()
         self.classifier = data.get('classifier', None)
-        # A classifier trained under older feature semantics (different
-        # downscaling / normalization) will silently mis-predict on the current
-        # feature values — warn so the user knows to retrain.
-        if (self.classifier is not None and
-                getattr(new_param, 'feature_semantics', None) != FEATURE_SEMANTICS_VERSION):
-            warnings.warn(
-                f"This model was saved with an older Convpaint whose feature computation "
-                f"differed (multi-scale downscaling and normalization of out-of-range float "
-                f"images have changed). Its classifier may predict poorly on features computed "
-                f"by this version — consider retraining and re-saving the model."
-            )
         if self.classifier is None:
             self.num_features = 0
         else:

--- a/src/napari_convpaint/convpaint_model.py
+++ b/src/napari_convpaint/convpaint_model.py
@@ -1,4 +1,5 @@
 import pickle
+import threading
 from pathlib import Path
 import importlib
 import inspect
@@ -144,6 +145,11 @@ class ConvpaintModel:
         self.num_features = 0
         self._fe_locked_device = None
         self._clf_locked_device = None
+        # Per-call shape bookkeeping written by _get_features and read back by
+        # _predict_image/_restore_shape. Thread-local because tiled prediction
+        # with use_dask runs tiles as threads sharing this one model instance
+        # (Client(processes=False)) — plain attributes would race across tiles.
+        self._shape_tls = threading.local()
         self._params_to_reset_training = ['channel_mode',
                                           'normalize',
                                         #   'image_downsample',
@@ -1071,6 +1077,40 @@ class ConvpaintModel:
             payload = fe.cacheable_repr(d, param, device)
             cache.put(key, payload, fe.cacheable_nbytes(payload))
         return fe.features_from_cacheable(payload, d.shape, param, patched=keep_patched)
+
+### PER-CALL SHAPE BOOKKEEPING (thread-local, see __init__)
+
+    @property
+    def original_shapes(self):
+        return getattr(self._shape_tls, "original_shapes", None)
+
+    @original_shapes.setter
+    def original_shapes(self, value):
+        self._shape_tls.original_shapes = value
+
+    @property
+    def pre_pad_shapes(self):
+        return getattr(self._shape_tls, "pre_pad_shapes", None)
+
+    @pre_pad_shapes.setter
+    def pre_pad_shapes(self, value):
+        self._shape_tls.pre_pad_shapes = value
+
+    @property
+    def padded_shapes(self):
+        return getattr(self._shape_tls, "padded_shapes", None)
+
+    @padded_shapes.setter
+    def padded_shapes(self, value):
+        self._shape_tls.padded_shapes = value
+
+    @property
+    def paddings(self):
+        return getattr(self._shape_tls, "paddings", None)
+
+    @paddings.setter
+    def paddings(self, value):
+        self._shape_tls.paddings = value
 
 ### BACKEND METHOD FOR FEATURE EXTRACTION
 

--- a/src/napari_convpaint/convpaint_model.py
+++ b/src/napari_convpaint/convpaint_model.py
@@ -1075,7 +1075,8 @@ class ConvpaintModel:
             if cache_only:
                 return None
             payload = fe.cacheable_repr(d, param, device)
-            cache.put(key, payload, fe.cacheable_nbytes(payload))
+            cache.put(key, payload, fe.cacheable_nbytes(payload),
+                      spill_ok=fe.cache_spill_to_disk())
         return fe.features_from_cacheable(payload, d.shape, param, patched=keep_patched)
 
 ### PER-CALL SHAPE BOOKKEEPING (thread-local, see __init__)

--- a/src/napari_convpaint/convpaint_model.py
+++ b/src/napari_convpaint/convpaint_model.py
@@ -40,17 +40,6 @@ TILE_ANNOT_MAX_BBOX_FRACTION = 0.5
 # block so at least a 2-block split happens.
 AUTO_TILE_MIN_SIDE = 1500
 
-# FE model names / aliases from earlier releases → their current equivalents,
-# so models saved (or scripts written) under the old names keep working.
-LEGACY_FE_NAMES = {
-    'dinov2_vits14_reg': 'dinov2_small-reg',
-    'dino_jafar_small': 'dinov2_small-reg_jafar',
-}
-LEGACY_ALIASES = {
-    'dino': 'dinov2',
-    'dino-jafar': 'dinov2-jafar',
-}
-
 # Version of the feature-computation semantics. Bump when a change alters the
 # numerical feature values (and therefore invalidates saved classifiers):
 #   1 (implicit) = pre-2026 releases (gaussian-blur+stride downscaling,
@@ -218,7 +207,6 @@ class ConvpaintModel:
 
         # If an alias is given, create an corresponding model
         if alias is not None:
-            alias = LEGACY_ALIASES.get(alias, alias)
             if alias in ConvpaintModel.STD_MODELS:
                 param = ConvpaintModel.STD_MODELS[alias]
             else:
@@ -553,10 +541,6 @@ class ConvpaintModel:
             data = safe_load(pkl_path)
             used_compat = True
         new_param = data.get('param', None)
-        # Remap legacy FE names on the loaded param itself (it replaces
-        # self._param below, so the remap in _set_fe alone would be lost).
-        if getattr(new_param, 'fe_name', None) in LEGACY_FE_NAMES:
-            new_param.fe_name = LEGACY_FE_NAMES[new_param.fe_name]
         # If there is the old use_gpu parameter saved, use lock_device to set the device policy for the feature extractor accordingly
         if hasattr(new_param, 'use_gpu'):
             device = 'gpu' if new_param.use_gpu else 'cpu'
@@ -618,10 +602,6 @@ class ConvpaintModel:
                 self.lock_device(device, part='both')
                 del params_to_set['use_gpu']
             new_param.set(**params_to_set)
-        # Remap legacy FE names on the loaded param itself (it replaces
-        # self._param below, so the remap in _set_fe alone would be lost).
-        if new_param.fe_name in LEGACY_FE_NAMES:
-            new_param.fe_name = LEGACY_FE_NAMES[new_param.fe_name]
         self._set_fe(new_param.fe_name, new_param.fe_layers)
         self._param = new_param
 
@@ -694,10 +674,6 @@ class ConvpaintModel:
         self.reset_classifier()
         self.reset_training()
 
-        # Remap FE names from earlier releases so the new name is also what
-        # gets stored in the param (and in future saves of this model).
-        fe_name = LEGACY_FE_NAMES.get(fe_name, fe_name)
-
         # Check if we need to create a new FE model
         fe_name_changed = fe_name != self._param.get("fe_name")
         fe_layers_changed = fe_layers != self._param.get("fe_layers")
@@ -740,12 +716,6 @@ class ConvpaintModel:
             The created feature extractor model
         """
         
-        # Remap FE names from earlier releases (e.g. saved models)
-        if name in LEGACY_FE_NAMES:
-            new_name = LEGACY_FE_NAMES[name]
-            warnings.warn(f"Feature extractor '{name}' was renamed to '{new_name}'; using the new name.")
-            name = new_name
-
         # Check if name is valid and create the feature extractor object
         if not name in ConvpaintModel.FE_MODELS_TYPES_DICT:
             raise ValueError(f'Feature extractor model {name} not found.')

--- a/src/napari_convpaint/convpaint_model.py
+++ b/src/napari_convpaint/convpaint_model.py
@@ -25,6 +25,40 @@ from . import utils
 # If the FE gives a Tile block size, we use this instead.
 DEFAULT_TARGET_TILE_BLOCK = 1000
 
+# Adaptive tile_annotations: tiling around annotations only saves feature-
+# extraction work when the annotations occupy a small part of the image. When
+# scribbles are spread across (most of) the image, the tiles cover it anyway and
+# the per-tile overhead makes many small tiles *slower* than one whole-image pass
+# (measured ~2x) for identical features. We gate on the fraction of the image
+# spanned by the overall annotation bounding box: only tile when it is below this.
+TILE_ANNOT_MAX_BBOX_FRACTION = 0.5
+
+# Auto-tile prediction (memory optimization for local-context FEs) once the image
+# is larger than this on its longest side — below it tiling would not split the
+# image into multiple blocks, so there is nothing to save. ~1.5x the default tile
+# block so at least a 2-block split happens.
+AUTO_TILE_MIN_SIDE = 1500
+
+
+def _tiling_worthwhile(annot, whole_area):
+    """Cheaply decide whether tiling around the annotations in `annot` is likely
+    faster than one whole-image feature extraction.
+
+    Uses the fraction of the image spanned by the overall annotation bounding box
+    (last two dims = spatial): a small box means the annotations are clustered and
+    tiling avoids most of the whole-image work; a box covering most of the image
+    means tiling would process it all anyway with extra per-tile overhead. Errs
+    toward whole-image (the safe, identical-feature default) for spread-out
+    annotations."""
+    coords = np.argwhere(annot > 0)
+    if coords.size == 0:
+        return False
+    # Spatial extent = last two axes of the annotation.
+    h = coords[:, -2].max() - coords[:, -2].min() + 1
+    w = coords[:, -1].max() - coords[:, -1].min() + 1
+    return (h * w) < TILE_ANNOT_MAX_BBOX_FRACTION * whole_area
+
+
 class ConvpaintModel:
     """
     The `ConvpaintModel` class is the core of Convpaint and **combines feature extraction with pixel classification**.
@@ -840,6 +874,63 @@ class ConvpaintModel:
                                use_dask=use_dask, fe_use_device=fe_use_device)
         return seg
 
+    def segment_to_disk(self, image, out, in_channels=None, skip_norm=True,
+                        fe_use_device=None):
+        """Segment a single (potentially larger-than-RAM) image, streaming tiles.
+
+        Reads the image one tile at a time and writes each tile's segmentation
+        into `out`, so neither the whole image nor the whole feature stack is ever
+        fully resident. Peak RAM stays at roughly one tile regardless of image
+        size.
+
+        Parameters
+        ----------
+        image : array-like [Z, H, W] / [H, W] / [C, Z, H, W] etc.
+            A lazily-sliceable input — e.g. ``np.memmap`` or a ``zarr`` array —
+            whose tiles are loaded on demand. A plain in-RAM ndarray also works
+            (but then the input is already resident).
+        out : array-like [Z, H, W] uint8
+            Preallocated, disk-backed output to write the segmentation into
+            (e.g. ``np.memmap(..., mode='w+')`` or a ``zarr`` array). Its shape
+            must equal the image's spatial dims with the channel dim removed and
+            a leading Z (Z = 1 for 2D input).
+        skip_norm : bool, default True
+            True means `image` is already normalized (required for genuine
+            out-of-core use with global-statistics normalization, which would
+            otherwise need the whole image in RAM). If False, the whole image is
+            normalized up front (only suitable when it fits in RAM).
+
+        Returns
+        -------
+        out : the same array passed in, now filled with the segmentation.
+
+        Notes
+        -----
+        This always tiles, so it is only accuracy-preserving for local-context
+        feature extractors; a warning is emitted for global-context FEs (a ViT's
+        features depend on the whole image and cannot be tiled).
+        """
+        if self.classifier is None:
+            raise ValueError('No trained classifier found.')
+
+        # Bring the input to [C, Z, H, W] (views only, no copy for memmap/zarr).
+        img = self._prep_dims_single(image)[0]
+
+        if in_channels is not None:
+            self._check_in_channels([img], in_channels)
+            img = img[in_channels]
+
+        if not skip_norm:
+            # Materializes the whole image; only for the RAM-fitting convenience
+            # case. True out-of-core requires a pre-normalized lazy input.
+            img = self._norm_single_image(img)
+
+        # Tiled prediction writing the segmentation straight into `out` on disk.
+        self._parallel_predict_image(
+            img, return_proba=False, use_dask=False,
+            fe_use_device=fe_use_device, out=out)
+        return out
+
     def predict_probas(self, image, in_channels=None, skip_norm=False, use_dask=False, fe_use_device=None):
         """
         Predicts the probabilities of the classes of the pixels in an image using the trained classifier.
@@ -1091,8 +1182,23 @@ class ConvpaintModel:
                 self._warn_if_global_context("tile_annotations")
                 coords = [None for _ in data] if coords is None else coords
                 alignment = self._get_fe_alignment(params_for_extract) # scalings_lcm * fe_patch
-                tiles = [utils.tile_annot(d, a, c, p, alignment=alignment, plot_tiles=False)
-                        for d, a, c, p in zip(data, annotations, coords, paddings)]
+                # Adaptive tiling: tile_annotations only saves work when the
+                # annotations are clustered. When scribbles are spread across the
+                # image, the padded bounding-box tiles cover most of it anyway and
+                # each tile adds fixed feature-extraction overhead — so many small
+                # tiles are *slower* than one whole-image pass (measured ~2x on
+                # spread-out scribbles) for identical features. Per image, keep the
+                # tiles only if they process meaningfully less than the whole image.
+                tiles = []
+                for d, a, c, p in zip(data, annotations, coords, paddings):
+                    if _tiling_worthwhile(a, d.shape[-2] * d.shape[-1]):
+                        trio = utils.tile_annot(d, a, c, p, alignment=alignment, plot_tiles=False)
+                    else:
+                        # Tiling this image would cost more than one whole-image
+                        # pass (too many scattered tiles, or tiles covering most
+                        # of it) — extract it whole. Features are identical.
+                        trio = ([d], [a], [c])
+                    tiles.append(trio)
                 data        = [t for trio in tiles for t in trio[0]]
                 annotations = [t for trio in tiles for t in trio[1]]
                 # Flat-repeat paddings for each tile (though not needed anymore, in case they are used later)
@@ -1264,16 +1370,27 @@ class ConvpaintModel:
         """
         nb_features = features.shape[0] # [nb_features, width, height]
 
-        # Move features to last dimension and flatten
+        # Move features to last dimension and flatten to [num_pixels, nb_features].
+        # reshape after moveaxis forces a contiguous copy of the whole feature
+        # stack (for a 2000px VGG16 image that is ~1.5 GB); predicting in row
+        # chunks bounds the extra peak memory to one chunk and keeps the result
+        # bit-identical. A single predict_proba/predict call on the full array
+        # is itself one uninterruptible multi-second call on large images.
         features = np.moveaxis(features, 0, -1)
         features = np.reshape(features, (-1, nb_features)) # flatten
 
-        # Predict
-        if return_proba:
-            predictions = self.classifier.predict_proba(features)
-            predictions = np.moveaxis(predictions, -1, 0) # [nb_classes, width*height]
+        chunk_size = 1_000_000
+        num_rows = features.shape[0]
+        predict_fn = self.classifier.predict_proba if return_proba else self.classifier.predict
+        if num_rows > chunk_size:
+            parts = [predict_fn(features[i:i+chunk_size])
+                     for i in range(0, num_rows, chunk_size)]
+            predictions = np.concatenate(parts, axis=0)
         else:
-            predictions = self.classifier.predict(features)
+            predictions = predict_fn(features)
+
+        if return_proba:
+            predictions = np.moveaxis(predictions, -1, 0) # [nb_classes, width*height]
 
         return predictions
 
@@ -1535,12 +1652,20 @@ class ConvpaintModel:
         if not skip_norm:
             data = [self._norm_single_image(d) for d in data]
 
-        # Get class probabilities, using tiling if enabled
+        # Get class probabilities, using tiling if enabled. Tiling holds only one
+        # tile's feature stack at a time instead of the whole-image stack
+        # (F x H x W), a large memory saving on big images, at identical output —
+        # but only for local-context FEs (a ViT's features depend on the whole
+        # image). It is auto-enabled per image when the image is large enough to
+        # actually be split; tile_image=True forces it regardless of size.
         if self._param.tile_image:
             probas = [self._parallel_predict_image(d, return_proba=True, use_dask=use_dask, fe_use_device=fe_use_device)
                       for d in data]
         else:
-            probas = self._predict_image(data, return_proba=True, fe_use_device=fe_use_device) # Can handle lists directly
+            probas = [self._parallel_predict_image(d, return_proba=True, use_dask=use_dask, fe_use_device=fe_use_device)
+                      if self._should_auto_tile(d.shape) else
+                      self._predict_image(d, return_proba=True, fe_use_device=fe_use_device)
+                      for d in data]
 
         # Restore input dimensionality (especially see if we want to remove z dimension)
         probas = [self._restore_dims(probas[i], input_shapes[i])
@@ -1558,6 +1683,19 @@ class ConvpaintModel:
                 return probas[0]
             else:
                 return probas
+
+    def _should_auto_tile(self, image_shape):
+        """Whether to tile prediction for an image even though tile_image is off.
+
+        Auto-tiling is a pure memory optimization (identical output), so only
+        applies to local-context FEs — for global-context FEs (ViT, cellpose)
+        tiling would change the features. It only kicks in once the image is
+        large enough that tiling actually splits it into multiple blocks;
+        otherwise there is nothing to gain."""
+        if self.fe_model.get_has_global_context():
+            return False
+        h, w = image_shape[-2], image_shape[-1]
+        return max(h, w) > AUTO_TILE_MIN_SIDE
 
     def _predict_image(self, image, return_proba=True, feature_img=None, fe_use_device=None):
         """
@@ -1615,7 +1753,7 @@ class ConvpaintModel:
             return pred_reshaped[0]
         return pred_reshaped
 
-    def _parallel_predict_image(self, image, return_proba=True, use_dask=False, fe_use_device=None, plot_tiles=False):
+    def _parallel_predict_image(self, image, return_proba=True, use_dask=False, fe_use_device=None, plot_tiles=False, out=None):
         """
         Backend method to predict an image using tiling and parallelization.
         Returns the class probabilities and optionally the segmentation of the images.
@@ -1624,6 +1762,14 @@ class ConvpaintModel:
         but always keeps the Z dim --> [C, Z, H, W] for class probas, [Z, H, W] for segmentation.
 
         NOTE: As opposed to other methods, this method only takes single images as input.
+
+        `out`, if given, is the array the stitched result is written into instead
+        of allocating it in RAM. Passing a disk-backed array (e.g. np.memmap or a
+        zarr array) keeps the full output off-heap; combined with a lazy `image`
+        (np.memmap / zarr) whose tiles are read on demand, peak RAM stays at about
+        one tile regardless of image size (out-of-core prediction). `out` must
+        match the result shape/dtype ([C,Z,H,W] float32 for probas, [Z,H,W] uint8
+        for segmentation).
         """
 
         self._warn_if_global_context("tile_image")
@@ -1646,21 +1792,37 @@ class ConvpaintModel:
 
         image = self._prep_dims_single(image)[0] # NOTE: should technically not be necessary, as done outside
 
-        # Prepare array to write the predictions to
+        # Prepare array to write the predictions to (or use the caller's `out`,
+        # e.g. a memmap, to keep the full output off-heap for out-of-core runs).
         if return_proba:
             num_classes = self.classifier.classes_.shape[0]
             z, h, w = image.shape[-3:]
-            predicted_image_complete = np.zeros((num_classes, z, h, w),
-                                                dtype=(np.float32))
+            expected_shape = (num_classes, z, h, w)
+            expected_dtype = np.float32
         else:
-            predicted_image_complete = np.zeros(image.shape[-3:], dtype=(np.uint8))
+            expected_shape = image.shape[-3:]
+            expected_dtype = np.uint8
+        if out is not None:
+            if tuple(out.shape) != tuple(expected_shape):
+                raise ValueError(f"out has shape {tuple(out.shape)}, expected {tuple(expected_shape)}.")
+            predicted_image_complete = out
+        else:
+            predicted_image_complete = np.zeros(expected_shape, dtype=expected_dtype)
 
-        # Prepare dask client if enabled
+        # Prepare dask client if enabled.
+        # NOTE (perf): use a threaded, single-process cluster (processes=False).
+        # A process-based cluster (the previous Client()) pickles every submitted
+        # task's arguments to worker processes — and because we submit the bound
+        # method self._predict_image, that pickles the whole ConvpaintModel
+        # (including the FE's torch weights) once per tile, plus it spawns worker
+        # processes on every call. With threads the model is shared in-process
+        # (no serialization, valid on MPS/GPU) and torch/numpy/catboost release
+        # the GIL during compute, so tiles still overlap.
         if use_dask:
             from dask.distributed import Client
             import dask
             dask.config.set({'distributed.worker.daemon': False})
-            client = Client()
+            client = Client(processes=False)
             processes = []
 
         # Iterate over the blocks of the image and predict each block separately
@@ -1705,7 +1867,10 @@ class ConvpaintModel:
                 if max_row > image.shape[-2]:
                     max_row = image.shape[-2]
 
-                image_block = image[..., min_row:max_row, min_col:max_col]
+                # np.asarray materializes just this block, so a lazy/disk-backed
+                # image (np.memmap / zarr / dask) only loads the tile being
+                # processed rather than the whole image.
+                image_block = np.asarray(image[..., min_row:max_row, min_col:max_col])
 
                 # For plotting:
                 # Take the entire image, add boarders for the block

--- a/src/napari_convpaint/convpaint_model.py
+++ b/src/napari_convpaint/convpaint_model.py
@@ -1443,24 +1443,26 @@ class ConvpaintModel:
         """
         nb_features = features.shape[0] # [nb_features, width, height]
 
-        # Move features to last dimension and flatten to [num_pixels, nb_features].
-        # reshape after moveaxis forces a contiguous copy of the whole feature
-        # stack (for a 2000px VGG16 image that is ~1.5 GB); predicting in row
-        # chunks bounds the extra peak memory to one chunk and keeps the result
-        # bit-identical. A single predict_proba/predict call on the full array
-        # is itself one uninterruptible multi-second call on large images.
-        features = np.moveaxis(features, 0, -1)
-        features = np.reshape(features, (-1, nb_features)) # flatten
-
-        chunk_size = 1_000_000
-        num_rows = features.shape[0]
+        # Move features to last dimension; this is a non-contiguous VIEW, so
+        # flattening it all at once would materialize a contiguous copy of the
+        # whole feature stack (for a 2000px VGG16 image that is ~1.5 GB).
+        # Instead, flatten and predict per block of leading rows of the view,
+        # so only one chunk-sized contiguous copy is alive at a time — the
+        # result is bit-identical to a full flatten+predict. A single
+        # predict_proba/predict call on the full array would also be one
+        # uninterruptible multi-second call on large images.
+        features = np.moveaxis(features, 0, -1)  # view [rows, ..., nb_features]
+        num_pixels = features.size // nb_features
+        pixels_per_row = max(1, num_pixels // features.shape[0])
+        rows_per_chunk = max(1, 1_000_000 // pixels_per_row)
         predict_fn = self.classifier.predict_proba if return_proba else self.classifier.predict
-        if num_rows > chunk_size:
-            parts = [predict_fn(features[i:i+chunk_size])
-                     for i in range(0, num_rows, chunk_size)]
+        if features.shape[0] > rows_per_chunk:
+            parts = [predict_fn(np.ascontiguousarray(features[i:i + rows_per_chunk])
+                                .reshape(-1, nb_features))
+                     for i in range(0, features.shape[0], rows_per_chunk)]
             predictions = np.concatenate(parts, axis=0)
         else:
-            predictions = predict_fn(features)
+            predictions = predict_fn(features.reshape(-1, nb_features))
 
         if return_proba:
             predictions = np.moveaxis(predictions, -1, 0) # [nb_classes, width*height]

--- a/src/napari_convpaint/convpaint_model.py
+++ b/src/napari_convpaint/convpaint_model.py
@@ -1059,7 +1059,8 @@ class ConvpaintModel:
         h.update(str(arr.dtype).encode())
         return h.hexdigest()
 
-    def _extract_pyramid_cached(self, d, param, keep_patched, device, cache_only=False):
+    def _extract_pyramid_cached(self, d, param, keep_patched, device, cache_only=False,
+                                key_memo=None, memo_idx=0):
         """Extract the feature pyramid for one image, consulting the feature
         cache. Behaviour with the cache disabled (the default) is exactly
         extract_features_pyramid; enabled, it caches/reuses the native features
@@ -1073,7 +1074,16 @@ class ConvpaintModel:
         fe = self.fe_model
         if cache is None or not cache.enabled or not fe.supports_feature_cache(param):
             return None if cache_only else fe.extract_features_pyramid(d, param, patched=keep_patched, device=device)
-        key = (self._data_hash(d), self._fe_cache_signature(param))
+        # `key_memo` (optional, supplied per prepared image by the caller) reuses
+        # the content hash computed by a preceding cache_only peek, so the
+        # compute pass doesn't hash the same padded array a second time.
+        if key_memo is not None and memo_idx in key_memo:
+            data_hash = key_memo[memo_idx]
+        else:
+            data_hash = self._data_hash(d)
+            if key_memo is not None:
+                key_memo[memo_idx] = data_hash
+        key = (data_hash, self._fe_cache_signature(param))
         payload = cache.get(key)
         if payload is None:
             if cache_only:
@@ -1122,7 +1132,8 @@ class ConvpaintModel:
     def _get_features(self, data, annotations=None, restore_input_form=True,
                           memory_mode=False, img_ids=None,
                           in_channels=None, skip_norm=False, use_device=None,
-                          pca_components=0, kmeans_clusters=0, cache_only=False):
+                          pca_components=0, kmeans_clusters=0, cache_only=False,
+                          key_memo=None):
         """
         Returns the features of images extracted by the feature extractor model.
 
@@ -1346,8 +1357,9 @@ class ConvpaintModel:
             warn=True,
         )
         features = [self._extract_pyramid_cached(
-                d, params_for_extract, keep_patched, fe_runtime_device, cache_only=cache_only)
-                    for d in data]
+                d, params_for_extract, keep_patched, fe_runtime_device, cache_only=cache_only,
+                key_memo=key_memo, memo_idx=i)
+                    for i, d in enumerate(data)]
 
         # cache_only peek: if any image's features are not already cached, signal
         # a miss so the caller can defer this image to the compute pass.
@@ -1741,7 +1753,8 @@ class ConvpaintModel:
 
         return features, annotations
 
-    def _predict(self, data, add_seg=False, in_channels=None, skip_norm=False, use_dask=False, fe_use_device=None, cache_only=False):
+    def _predict(self, data, add_seg=False, in_channels=None, skip_norm=False, use_dask=False, fe_use_device=None, cache_only=False,
+                 key_memo=None):
         """
         Backend method to predict images as a whole or tiling and parallelizing the prediction.
 
@@ -1778,6 +1791,9 @@ class ConvpaintModel:
         # but only for local-context FEs (a ViT's features depend on the whole
         # image). It is auto-enabled per image when the image is large enough to
         # actually be split; tile_image=True forces it regardless of size.
+        # The cache-key memo is only unambiguous for single-image calls (its
+        # indices refer to positions within one prepared-data list).
+        key_memo = key_memo if len(data) == 1 else None
         if cache_only:
             # Peek: only serve images whose features are already cached; return
             # None on any miss so the caller defers it to the compute pass. The
@@ -1786,7 +1802,8 @@ class ConvpaintModel:
             probas = []
             for d in data:
                 p = (None if (self._param.tile_image or self._should_auto_tile(d.shape))
-                     else self._predict_image(d, return_proba=True, fe_use_device=fe_use_device, cache_only=True))
+                     else self._predict_image(d, return_proba=True, fe_use_device=fe_use_device, cache_only=True,
+                                              key_memo=key_memo))
                 if p is None:
                     return None
                 probas.append(p)
@@ -1796,7 +1813,7 @@ class ConvpaintModel:
         else:
             probas = [self._parallel_predict_image(d, return_proba=True, use_dask=use_dask, fe_use_device=fe_use_device)
                       if self._should_auto_tile(d.shape) else
-                      self._predict_image(d, return_proba=True, fe_use_device=fe_use_device)
+                      self._predict_image(d, return_proba=True, fe_use_device=fe_use_device, key_memo=key_memo)
                       for d in data]
 
         # Restore input dimensionality (especially see if we want to remove z dimension)
@@ -1829,7 +1846,8 @@ class ConvpaintModel:
         h, w = image_shape[-2], image_shape[-1]
         return max(h, w) > AUTO_TILE_MIN_SIDE
 
-    def _predict_image(self, image, return_proba=True, feature_img=None, fe_use_device=None, cache_only=False):
+    def _predict_image(self, image, return_proba=True, feature_img=None, fe_use_device=None, cache_only=False,
+                       key_memo=None):
         """
         Backend method to predict images without tiling and parallelization.
         Returns the class probabilities and optionally the segmentation of the images.
@@ -1851,7 +1869,8 @@ class ConvpaintModel:
                                             in_channels=None, # already extracted outside
                                             skip_norm=True, # already normalized outside
                                             use_device=fe_use_device,
-                                            cache_only=cache_only)
+                                            cache_only=cache_only,
+                                            key_memo=key_memo)
             if feature_img is None:  # cache_only peek: features not cached
                 return None
 

--- a/src/napari_convpaint/convpaint_widget.py
+++ b/src/napari_convpaint/convpaint_widget.py
@@ -1680,11 +1680,17 @@ class ConvpaintWidget(QWidget):
         # plugin itself removes/recreates its own probabilities/features layers
         # (e.g. after a class-count change), which must never wipe the cache.
         removed = getattr(event, 'value', None) if event is not None else None
-        plugin_layer_names = {self.proba_prefix, self.features_prefix}
+
+        def _is_plugin_image(name):
+            # Live plugin layers are named exactly proba_prefix/features_prefix;
+            # backups renamed on image switch get a '<prefix>_<tag>' suffix.
+            return any(name == p or name.startswith(p + '_')
+                       for p in (self.proba_prefix, self.features_prefix))
+
         if (isinstance(removed, napari.layers.Image)
-                and removed.name not in plugin_layer_names):
+                and not _is_plugin_image(removed.name)):
             user_images_left = any(
-                isinstance(l, napari.layers.Image) and l.name not in plugin_layer_names
+                isinstance(l, napari.layers.Image) and not _is_plugin_image(l.name)
                 for l in self.viewer.layers)
             if not user_images_left:
                 fc = getattr(getattr(self, 'cp_model', None), '_feature_cache', None)

--- a/src/napari_convpaint/convpaint_widget.py
+++ b/src/napari_convpaint/convpaint_widget.py
@@ -1673,15 +1673,24 @@ class ConvpaintWidget(QWidget):
         self.annot_layers = {l for l in self.annot_layers if l is None or l.name in self.viewer.layers}
         self.seg_layers = {l for l in self.seg_layers if l is None or l.name in self.viewer.layers}
 
-        # Clear the feature cache when an IMAGE layer is removed: entries are keyed
-        # by image content (which is now gone), so they would otherwise linger in
-        # RAM/disk until evicted. The cache repopulates lazily on the next use.
+        # Clear the feature cache only when the LAST user image layer is removed.
+        # The cache is content-addressed (a removed image's entries simply stop
+        # hitting and age out via LRU), so clearing on every removal would throw
+        # away valid entries for the images still open — including when the
+        # plugin itself removes/recreates its own probabilities/features layers
+        # (e.g. after a class-count change), which must never wipe the cache.
         removed = getattr(event, 'value', None) if event is not None else None
-        if isinstance(removed, napari.layers.Image):
-            fc = getattr(getattr(self, 'cp_model', None), '_feature_cache', None)
-            if fc is not None:
-                fc.clear()
-                self._refresh_cache_size_label()
+        plugin_layer_names = {self.proba_prefix, self.features_prefix}
+        if (isinstance(removed, napari.layers.Image)
+                and removed.name not in plugin_layer_names):
+            user_images_left = any(
+                isinstance(l, napari.layers.Image) and l.name not in plugin_layer_names
+                for l in self.viewer.layers)
+            if not user_images_left:
+                fc = getattr(getattr(self, 'cp_model', None), '_feature_cache', None)
+                if fc is not None:
+                    fc.clear()
+                    self._refresh_cache_size_label()
 
     # Layer selection
 

--- a/src/napari_convpaint/convpaint_widget.py
+++ b/src/napari_convpaint/convpaint_widget.py
@@ -3541,7 +3541,7 @@ class ConvpaintWidget(QWidget):
 
     def _get_current_plane_norm(self):
         """Get the current image plane to predict on, normalized according to the settings."""
-        from .utils import normalize_image, normalize_image_imagenet
+        from .utils import normalize_image
         
         # Get image and the info needed about normalization
         img = self._get_selected_img(check=True)
@@ -3561,11 +3561,16 @@ class ConvpaintWidget(QWidget):
             self._compute_image_stats(img)
 
         # Get image data and stats depending on the data dim and norm mode
-        if fe_norm != "percentile":
-            # For default and imagenet norm, we want unnormalized data to apply normalization only on the current plane
+        if use_default:
+            # For default norm, we want unnormalized data to apply normalization only on the current plane
             img = self._get_data_channel_first(img.data, img.ndim) if img is not None else None
-        else: # "percentile"
-            # For percentile norm, we want already normalized data to avoid artifacts when normalizing only the current plane
+        else: # "percentile" or "imagenet"
+            # For percentile AND imagenet norm, we want already normalized data
+            # (stack-scope stats) to avoid artifacts when normalizing only the
+            # current plane: imagenet norm percentile-stretches out-of-range
+            # float input, so normalizing a single plane would use different
+            # lo/hi than training on the whole stack did — the same pixels
+            # would get different features between train and predict.
             img = self._get_data_channel_first_norm(img)
 
         if data_dims in ['2D', '2D_RGB', '3D_multi'] or data_dims not in self.supported_data_dims:
@@ -3601,19 +3606,13 @@ class ConvpaintWidget(QWidget):
                 image_mean = self.image_mean[:,step]
                 image_std = self.image_std[:,step]
 
-        # Normalize image (for default: use the stats based on the radio buttons; for imagenet: stats are fixed)
+        # Normalize image (for default: use the stats based on the radio buttons)
         if norm_scope != 1:
             if use_default:
                 image_plane = normalize_image(image=image_plane, image_mean=image_mean, image_std=image_std)
-            elif fe_norm == "imagenet":
-                # Only if rgb image --> array with 3 or 4 dims, with C=3 first
-                if self.cp_model.get_param("channel_mode") == 'rgb': # Double-check (actually redundant due to check above)
-                    image_plane = normalize_image_imagenet(image=image_plane)
-                else:
-                    print("WIDGET _ON_PREDICT(): THIS SHOULD NOT BE HAPPENING, AS WE CHECKED ABOVE FOR RGB")
-                    image_plane = normalize_image(image=image_plane, image_mean=image_mean, image_std=image_std)
-            # For percentile norm, image is already normalized above (before selecting the plane)
-        
+            # For percentile and imagenet norm, the image is already normalized
+            # above with stack-scope statistics (before selecting the plane)
+
         return image_plane
 
     def _compute_image_stats(self, img):

--- a/src/napari_convpaint/convpaint_widget.py
+++ b/src/napari_convpaint/convpaint_widget.py
@@ -2630,8 +2630,9 @@ class ConvpaintWidget(QWidget):
                 setattr(new_param, attr, val) # Set the default value in the param object
         if adjusted_params: show_info(f'The feature extractor adjusted the parameters {adjusted_params}')
 
-        # Create a new model with the new FE
-        self.cp_model = self._cpm_class(param=new_param)
+        # Create a new model with the new FE, reusing the temp FE instance so
+        # heavy extractors (torch weights) are not loaded a second time.
+        self.cp_model = self._cpm_class(param=new_param, _fe_model=temp_fe_model_for_defaults)
         self._apply_feature_cache(recreate=True)
         self._reset_device_options()
         self._reset_clf() # Call to take all actions needed after resetting the clf

--- a/src/napari_convpaint/convpaint_widget.py
+++ b/src/napari_convpaint/convpaint_widget.py
@@ -1750,9 +1750,15 @@ class ConvpaintWidget(QWidget):
             pbr.set_description(f"Training")
             img_name = self._get_selected_img().name
             in_channels = self._parse_in_channels(self.input_channels)
-            # Train the model with the current image and annotations; skip normalization as it is done in the widget
+            # Train the model with the current image and annotations; skip
+            # normalization as it is already done in the widget (image_stack_norm).
+            # Prediction already passes skip_norm=True on the same pre-normalized
+            # data; matching that here avoids a redundant second normalization
+            # pass (a no-op for imagenet FEs, but wasted compute; and it fixes the
+            # erroneous double-application for percentile FEs), and keeps
+            # train/predict consistent so their features match.
             _ = self.cp_model.train(image_stack_norm, annot, memory_mode=mem_mode, img_ids=img_name,
-                                    in_channels=in_channels, skip_norm=False,
+                                    in_channels=in_channels, skip_norm=True,
                                     fe_use_device=self.fe_device, clf_use_device=self.clf_device)
             self._update_training_counts()
     

--- a/src/napari_convpaint/convpaint_widget.py
+++ b/src/napari_convpaint/convpaint_widget.py
@@ -2039,6 +2039,10 @@ class ConvpaintWidget(QWidget):
         in_channels = self._parse_in_channels(self.input_channels)
         self._predict_all_probas_ready = False
 
+        # Per-slice cache-key memos: the compute pass reuses the content hash
+        # the cache peek already computed instead of re-hashing the slice.
+        key_memos = {}
+
         def _predict_and_write(step, cache_only):
             """Predict one slice and write it to the layers. With cache_only=True,
             only slices whose features are already cached are predicted (returns
@@ -2047,7 +2051,8 @@ class ConvpaintWidget(QWidget):
             image = image_stack_norm[..., step, :, :]
             out = self.cp_model._predict(image, add_seg=True, in_channels=in_channels,
                                          skip_norm=True, use_dask=self.use_dask,
-                                         fe_use_device=self.fe_device, cache_only=cache_only)
+                                         fe_use_device=self.fe_device, cache_only=cache_only,
+                                         key_memo=key_memos.setdefault(step, {}))
             if out is None:  # cache_only peek: this slice is not cached yet
                 return False
             probas, seg = out

--- a/src/napari_convpaint/convpaint_widget.py
+++ b/src/napari_convpaint/convpaint_widget.py
@@ -577,9 +577,19 @@ class ConvpaintWidget(QWidget):
             self.cache_max_ram_spinbox.setValue(self.cache_max_mb)
             self.advanced_cache_group.glayout.addWidget(self.cache_max_ram_spinbox, 2, 2, 1, 1)
 
-            # Current cache size label
+            # Max disk spinbox (MB) — features evicted from RAM spill here instead
+            # of being recomputed. 0 disables disk spillover.
+            self.cache_max_disk_label = QLabel('Max cache disk (MB, 0 = RAM only)')
+            self.advanced_cache_group.glayout.addWidget(self.cache_max_disk_label, 3, 0, 1, 2)
+            self.cache_max_disk_spinbox = QSpinBox()
+            self.cache_max_disk_spinbox.setRange(0, 8 * 1024 * 1024)  # 0 .. 8 TB
+            self.cache_max_disk_spinbox.setSingleStep(1024)
+            self.cache_max_disk_spinbox.setValue(self.cache_disk_max_mb)
+            self.advanced_cache_group.glayout.addWidget(self.cache_max_disk_spinbox, 3, 2, 1, 1)
+
+            # Current cache size label (RAM + disk)
             self.cache_size_label = QLabel('Current cache size: 0 MB')
-            self.advanced_cache_group.glayout.addWidget(self.cache_size_label, 3, 0, 1, 3)
+            self.advanced_cache_group.glayout.addWidget(self.cache_size_label, 4, 0, 1, 3)
 
         # === MULTIFILE TAB ===
 
@@ -906,21 +916,30 @@ class ConvpaintWidget(QWidget):
         model = getattr(self, "cp_model", None)
         if model is None:
             return
-        max_bytes = int(self.cache_max_mb) * 1024 * 1024
+        # Use decimal MB (1e6) here to match the size shown in the label (also
+        # /1e6), so the number the user types is exactly the max size displayed.
+        max_bytes = int(self.cache_max_mb) * 1_000_000
+        disk_max_bytes = int(self.cache_disk_max_mb) * 1_000_000
         fc = getattr(model, "_feature_cache", None)
         if fc is None or recreate:
-            model.enable_feature_cache(enabled=self.cache_enabled, max_bytes=max_bytes)
+            model.enable_feature_cache(enabled=self.cache_enabled, max_bytes=max_bytes,
+                                       disk_max_bytes=disk_max_bytes)
         else:
             fc.set_max_bytes(max_bytes)
+            fc.set_disk_max_bytes(disk_max_bytes)
             fc.set_enabled(self.cache_enabled)
         self._refresh_cache_size_label()
 
     def _on_cache_enabled_toggled(self, checked=None):
         self.cache_enabled = self.check_use_cache.isChecked()
-        self._apply_feature_cache()  # set_enabled(False) clears it, freeing RAM
+        self._apply_feature_cache()  # set_enabled(False) clears it, freeing RAM+disk
 
     def _on_cache_max_ram_changed(self, value=None):
         self.cache_max_mb = self.cache_max_ram_spinbox.value()
+        self._apply_feature_cache()
+
+    def _on_cache_max_disk_changed(self, value=None):
+        self.cache_disk_max_mb = self.cache_max_disk_spinbox.value()
         self._apply_feature_cache()
 
     def _refresh_cache_size_label(self):
@@ -932,7 +951,8 @@ class ConvpaintWidget(QWidget):
             self.cache_size_label.setText('Current cache size: 0 MB')
             return
         self.cache_size_label.setText(
-            f'Current cache size: {fc.nbytes / 1e6:.0f} MB ({len(fc)} entries)')
+            f'Current cache size: RAM {fc.nbytes / 1e6:.0f} MB ({len(fc)}), '
+            f'disk {fc.disk_nbytes / 1e6:.0f} MB ({fc.stats()["disk_entries"]})')
 
     def _late_init(self):
         """Populate UI widgets with defaults from ConvpaintModel, set up connections, and reset model.
@@ -1129,6 +1149,7 @@ class ConvpaintWidget(QWidget):
             if hasattr(self, 'check_use_cache'):
                 self.check_use_cache.stateChanged.connect(self._on_cache_enabled_toggled)
                 self.cache_max_ram_spinbox.valueChanged.connect(self._on_cache_max_ram_changed)
+                self.cache_max_disk_spinbox.valueChanged.connect(self._on_cache_max_disk_changed)
                 # Keep the "current cache size" label live.
                 self._cache_size_timer = QTimer(self)
                 self._cache_size_timer.setInterval(1000)
@@ -1652,6 +1673,16 @@ class ConvpaintWidget(QWidget):
         self.annot_layers = {l for l in self.annot_layers if l is None or l.name in self.viewer.layers}
         self.seg_layers = {l for l in self.seg_layers if l is None or l.name in self.viewer.layers}
 
+        # Clear the feature cache when an IMAGE layer is removed: entries are keyed
+        # by image content (which is now gone), so they would otherwise linger in
+        # RAM/disk until evicted. The cache repopulates lazily on the next use.
+        removed = getattr(event, 'value', None) if event is not None else None
+        if isinstance(removed, napari.layers.Image):
+            fc = getattr(getattr(self, 'cp_model', None), '_feature_cache', None)
+            if fc is not None:
+                fc.clear()
+                self._refresh_cache_size_label()
+
     # Layer selection
 
     def _on_select_layer(self, newtext=None):
@@ -2003,35 +2034,66 @@ class ConvpaintWidget(QWidget):
         # Get normalized stack data (entire stack, and stats prepared given the radio buttons)
         image_stack_norm = self._get_data_channel_first_norm(img) # Normalize the entire stack
         
-        # Step through the stack and predict each image
+        # Step through the stack and predict each image.
         num_steps = image_stack_norm.shape[-3]
-        for step in progress(range(num_steps)):
+        in_channels = self._parse_in_channels(self.input_channels)
+        self._predict_all_probas_ready = False
 
-            # Take the slice of the 3rd last dimension (since images are C, Z, H, W or Z, H, W)
+        def _predict_and_write(step, cache_only):
+            """Predict one slice and write it to the layers. With cache_only=True,
+            only slices whose features are already cached are predicted (returns
+            False on a miss, without running the extractor). Returns True if
+            written."""
             image = image_stack_norm[..., step, :, :]
-
-            # Predict the current step; skip normalization as it is done above
-            in_channels = self._parse_in_channels(self.input_channels)
-            # Use the backend function which returns probabilities and segmentation
-            probas, seg = self.cp_model._predict(image, add_seg=True, in_channels=in_channels, skip_norm=True,
-                                                 use_dask=self.use_dask, fe_use_device=self.fe_device)
-
-            # In the first iteration, check if we need to create a new probas layer
-            # (we need the information about the number of classes)
-            if step == 0 and self.add_probas:
-                num_classes = probas.shape[0]
-                # Check if we need to create a new probabilities layer
-                self._check_create_probas_layer(num_classes)
-                # Set the flag to False, so we don't create a new layer every time
+            out = self.cp_model._predict(image, add_seg=True, in_channels=in_channels,
+                                         skip_norm=True, use_dask=self.use_dask,
+                                         fe_use_device=self.fe_device, cache_only=cache_only)
+            if out is None:  # cache_only peek: this slice is not cached yet
+                return False
+            probas, seg = out
+            # Create the probabilities layer on the first actual prediction (we
+            # need the class count); with cache-first ordering this may not be
+            # step 0.
+            if self.add_probas and not self._predict_all_probas_ready:
+                self._check_create_probas_layer(probas.shape[0])
                 self.new_proba = False
-
-            # Add the slices to the segmentation and probabilities layers
+                self._predict_all_probas_ready = True
             if self.add_seg:
                 self.viewer.layers[self.seg_tag].data[step] = seg
                 self.viewer.layers[self.seg_tag].refresh()
             if self.add_probas:
                 self.viewer.layers[self.proba_prefix].data[..., step, :, :] = probas
                 self.viewer.layers[self.proba_prefix].refresh()
+            return True
+
+        fc = getattr(self.cp_model, "_feature_cache", None)
+        cache_primed = (fc is not None and fc.enabled
+                        and (len(fc) + fc.stats().get("disk_entries", 0)) > 0)
+        if self.cache_enabled and cache_primed:
+            # Cache-first ordering: serve slices already in the cache before
+            # computing the rest. A plain sequential scan over a stack larger than
+            # the cache evicts the very slices the next pass needs first (classic
+            # LRU thrash) — so cached slices would be recomputed for no benefit.
+            # Predicting cached slices first guarantees they are used before the
+            # compute pass evicts them. Both phases share ONE progress bar over all
+            # slices. (Skipped when the cache is empty — nothing to serve first.)
+            with progress(total=num_steps) as pbr:
+                pbr.set_description("Predicting")
+                done = [False] * num_steps
+                for step in range(num_steps):          # phase 1: already-cached slices
+                    if _predict_and_write(step, cache_only=True):
+                        done[step] = True
+                        pbr.update(1)
+                for step in range(num_steps):          # phase 2: compute the rest
+                    if not done[step]:
+                        _predict_and_write(step, cache_only=False)
+                        pbr.update(1)
+        else:
+            with progress(total=num_steps) as pbr:
+                pbr.set_description("Predicting")
+                for step in range(num_steps):
+                    _predict_and_write(step, cache_only=False)
+                    pbr.update(1)
 
         with warnings.catch_warnings():
             warnings.simplefilter(action="ignore", category=FutureWarning)
@@ -2371,6 +2433,7 @@ class ConvpaintWidget(QWidget):
         self.use_dask = False # Use Dask for parallel processing
         self.cache_enabled = True # Reuse extracted features when re-segmenting / re-training the same image
         self.cache_max_mb = 2048 # Max RAM (MB) the feature cache may use (moderate default)
+        self.cache_disk_max_mb = 8192 # Max disk (MB) for spilled features (0 = disk spillover off)
         self.fe_device = 'auto' # Device to use for the FE (if applicable); 'auto' will use GPU if available, otherwise CPU
         self.clf_device = 'auto' # Device to use for the classifier (if applicable); 'auto' will use GPU if available, otherwise CPU
         self.input_channels = "" # Input channels for the model (as txt, will be parsed)

--- a/src/napari_convpaint/convpaint_widget.py
+++ b/src/napari_convpaint/convpaint_widget.py
@@ -547,6 +547,40 @@ class ConvpaintWidget(QWidget):
             self.advanced_unsupervised_group.glayout.addWidget(self.kmeans_label, 1, 0, 1, 2)
             self.advanced_unsupervised_group.glayout.addWidget(self.text_features_kmeans, 1, 2, 1, 2)
 
+        # === PERFORMANCE TAB ===
+
+        if 'Advanced' in self.tab_names:
+            self.advanced_cache_group = VHGroup('Feature caching', orientation='G')
+            self.tabs.add_named_tab('Advanced', self.advanced_cache_group.gbox)
+
+            # Explanatory note
+            cache_note = QLabel(
+                "Reuse extracted features when segmenting or training the same image "
+                "repeatedly (e.g. while refining annotations), instead of recomputing "
+                "them. Bounded by the memory limit below; on stacks/movies the oldest "
+                "cached slices are dropped first.")
+            cache_note.setStyleSheet(style_for_infos)
+            cache_note.setWordWrap(True)
+            self.advanced_cache_group.glayout.addWidget(cache_note, 0, 0, 1, 3)
+
+            # Enable/disable checkbox
+            self.check_use_cache = QCheckBox('Enable feature caching')
+            self.check_use_cache.setChecked(self.cache_enabled)
+            self.advanced_cache_group.glayout.addWidget(self.check_use_cache, 1, 0, 1, 3)
+
+            # Max RAM spinbox (MB)
+            self.cache_max_ram_label = QLabel('Max cache RAM (MB)')
+            self.advanced_cache_group.glayout.addWidget(self.cache_max_ram_label, 2, 0, 1, 2)
+            self.cache_max_ram_spinbox = QSpinBox()
+            self.cache_max_ram_spinbox.setRange(64, 1024 * 1024)  # 64 MB .. 1 TB
+            self.cache_max_ram_spinbox.setSingleStep(256)
+            self.cache_max_ram_spinbox.setValue(self.cache_max_mb)
+            self.advanced_cache_group.glayout.addWidget(self.cache_max_ram_spinbox, 2, 2, 1, 1)
+
+            # Current cache size label
+            self.cache_size_label = QLabel('Current cache size: 0 MB')
+            self.advanced_cache_group.glayout.addWidget(self.cache_size_label, 3, 0, 1, 3)
+
         # === MULTIFILE TAB ===
 
         if 'Multifile' in self.tab_names:
@@ -864,6 +898,42 @@ class ConvpaintWidget(QWidget):
             from .convpaint_model import ConvpaintModel
             self._cpm_class = ConvpaintModel
 
+    def _apply_feature_cache(self, recreate=False):
+        """Apply the current caching settings (enabled + max RAM) to the active
+        model. Pass recreate=True right after the model is (re)created; otherwise
+        the existing cache is updated in place so its entries survive a settings
+        change."""
+        model = getattr(self, "cp_model", None)
+        if model is None:
+            return
+        max_bytes = int(self.cache_max_mb) * 1024 * 1024
+        fc = getattr(model, "_feature_cache", None)
+        if fc is None or recreate:
+            model.enable_feature_cache(enabled=self.cache_enabled, max_bytes=max_bytes)
+        else:
+            fc.set_max_bytes(max_bytes)
+            fc.set_enabled(self.cache_enabled)
+        self._refresh_cache_size_label()
+
+    def _on_cache_enabled_toggled(self, checked=None):
+        self.cache_enabled = self.check_use_cache.isChecked()
+        self._apply_feature_cache()  # set_enabled(False) clears it, freeing RAM
+
+    def _on_cache_max_ram_changed(self, value=None):
+        self.cache_max_mb = self.cache_max_ram_spinbox.value()
+        self._apply_feature_cache()
+
+    def _refresh_cache_size_label(self):
+        if not hasattr(self, "cache_size_label"):
+            return
+        model = getattr(self, "cp_model", None)
+        fc = getattr(model, "_feature_cache", None) if model is not None else None
+        if fc is None:
+            self.cache_size_label.setText('Current cache size: 0 MB')
+            return
+        self.cache_size_label.setText(
+            f'Current cache size: {fc.nbytes / 1e6:.0f} MB ({len(fc)} entries)')
+
     def _late_init(self):
         """Populate UI widgets with defaults from ConvpaintModel, set up connections, and reset model.
         This is called after the GUI is shown to ensure that all components are properly initialized."""
@@ -871,6 +941,7 @@ class ConvpaintWidget(QWidget):
         # === MODEL DEFAULTS & WIDGET POPULATION ===
         self._import_convpaint_model_class()
         self.cp_model = self._cpm_class()
+        self._apply_feature_cache(recreate=True)
         # Get default parameters to set in widget
         self.default_cp_param = self._cpm_class.get_default_params()
         # Use variables of main model as temp variables for the Models tab, as it is the one model used at that time
@@ -1054,6 +1125,15 @@ class ConvpaintWidget(QWidget):
 
             self.check_use_dask.stateChanged.connect(lambda: setattr(
                 self, 'use_dask', self.check_use_dask.isChecked()))
+
+            if hasattr(self, 'check_use_cache'):
+                self.check_use_cache.stateChanged.connect(self._on_cache_enabled_toggled)
+                self.cache_max_ram_spinbox.valueChanged.connect(self._on_cache_max_ram_changed)
+                # Keep the "current cache size" label live.
+                self._cache_size_timer = QTimer(self)
+                self._cache_size_timer.setInterval(1000)
+                self._cache_size_timer.timeout.connect(self._refresh_cache_size_label)
+                self._cache_size_timer.start()
 
             self.text_input_channels.textChanged.connect(lambda: setattr(
                 self, 'input_channels', self.text_input_channels.text()))
@@ -2115,6 +2195,7 @@ class ConvpaintWidget(QWidget):
 
         # Load the model (Note: done after updating GUI, since GUI updates might reset clf or change model)
         self.cp_model = new_model
+        self._apply_feature_cache(recreate=True)
         self.cp_model._param = new_param
         temp_fe_model = self._cpm_class.create_fe(new_param.fe_name)
         self.temp_fe_description = temp_fe_model.get_description()
@@ -2288,6 +2369,8 @@ class ConvpaintWidget(QWidget):
         self.features_prefix = 'features' # Prefix for the feature image layer name
         self.cont_training = "Image" # Update features for subsequent training ("Image" or "Off" or "Global")
         self.use_dask = False # Use Dask for parallel processing
+        self.cache_enabled = True # Reuse extracted features when re-segmenting / re-training the same image
+        self.cache_max_mb = 2048 # Max RAM (MB) the feature cache may use (moderate default)
         self.fe_device = 'auto' # Device to use for the FE (if applicable); 'auto' will use GPU if available, otherwise CPU
         self.clf_device = 'auto' # Device to use for the classifier (if applicable); 'auto' will use GPU if available, otherwise CPU
         self.input_channels = "" # Input channels for the model (as txt, will be parsed)
@@ -2481,6 +2564,7 @@ class ConvpaintWidget(QWidget):
 
         # Create a new model with the new FE
         self.cp_model = self._cpm_class(param=new_param)
+        self._apply_feature_cache(recreate=True)
         self._reset_device_options()
         self._reset_clf() # Call to take all actions needed after resetting the clf
         # Reset the features for continuous training

--- a/src/napari_convpaint/feature_cache.py
+++ b/src/napari_convpaint/feature_cache.py
@@ -80,7 +80,7 @@ class FeatureCache:
                  enabled: bool = True,
                  disk_max_bytes: int = 0,
                  disk_dir: str | None = None):
-        self._store: "OrderedDict[tuple, tuple]" = OrderedDict()  # key -> (payload, nbytes)
+        self._store: "OrderedDict[tuple, tuple]" = OrderedDict()  # key -> (payload, nbytes, spill_ok)
         self._total_bytes = 0
         self._headroom_frac = float(headroom_frac)
         self.enabled = bool(enabled)
@@ -148,33 +148,45 @@ class FeatureCache:
         self.misses += 1
         return None
 
-    def put(self, key, payload, nbytes: int | None = None):
+    def put(self, key, payload, nbytes: int | None = None, spill_ok: bool = True):
         """Store `payload` under `key` if it fits the budget; else evict LRU and
-        retry, and if it still does not fit, skip caching (caller recomputes)."""
+        retry. A payload that can never fit the RAM tier goes straight to the
+        disk tier (if `spill_ok` and it fits the disk budget); otherwise caching
+        is skipped and the caller recomputes. `spill_ok=False` keeps a payload
+        out of the disk tier entirely (RAM only, evict = drop) — for FEs whose
+        payloads are huge relative to their recompute cost."""
         if not self.enabled or payload is None:
             return
         if nbytes is None:
             nbytes = _payload_nbytes(payload)
-        # A single payload larger than the whole cap can never be cached safely.
-        if nbytes > self._max_bytes:
-            return
         # Overwrite of an existing key: drop the old size first.
         if key in self._store:
             self._total_bytes -= self._store.pop(key)[1]
+        # A single payload larger than the whole RAM cap can never be held in
+        # RAM — route it directly to the disk tier instead of dropping it.
+        if nbytes > self._max_bytes:
+            if spill_ok:
+                self._spill_to_disk(key, payload, nbytes)
+            return
         # Evict least-recently-used until the new entry fits.
         while self._store and not self._fits(nbytes):
             self._evict_one()
         if not self._fits(nbytes):
-            return  # even empty it doesn't fit the live headroom → don't cache
-        self._store[key] = (payload, nbytes)
+            # The live headroom refuses it even with the RAM tier empty; the
+            # disk tier can still hold it.
+            if spill_ok:
+                self._spill_to_disk(key, payload, nbytes)
+            return
+        self._store[key] = (payload, nbytes, spill_ok)
         self._store.move_to_end(key)
         self._total_bytes += nbytes
 
     def _evict_one(self):
-        key, (payload, nbytes) = self._store.popitem(last=False)  # LRU = oldest
+        key, (payload, nbytes, spill_ok) = self._store.popitem(last=False)  # LRU = oldest
         self._total_bytes -= nbytes
         # Spill to the disk tier instead of dropping (if disk spillover is on).
-        self._spill_to_disk(key, payload, nbytes)
+        if spill_ok:
+            self._spill_to_disk(key, payload, nbytes)
 
     # -- disk tier ---------------------------------------------------------
 

--- a/src/napari_convpaint/feature_cache.py
+++ b/src/napari_convpaint/feature_cache.py
@@ -23,6 +23,10 @@ payload.
 """
 from __future__ import annotations
 
+import os
+import pickle
+import shutil
+import tempfile
 from collections import OrderedDict
 
 try:
@@ -37,6 +41,9 @@ _DEFAULT_MAX_BYTES = 2 * 1024 ** 3  # 2 GiB
 # Keep at least this fraction of currently-available RAM free (never consume it
 # all with cache), as a safety headroom against OOM.
 _DEFAULT_HEADROOM_FRAC = 0.25
+# Never write disk-cache data that would leave less than this much free on the
+# target filesystem — so the disk cache can't fill the user's disk.
+_DISK_HEADROOM_BYTES = 2 * 1024 ** 3  # 2 GiB
 
 
 def _payload_nbytes(payload) -> int:
@@ -70,7 +77,9 @@ class FeatureCache:
 
     def __init__(self, max_bytes: int | None = None,
                  headroom_frac: float = _DEFAULT_HEADROOM_FRAC,
-                 enabled: bool = True):
+                 enabled: bool = True,
+                 disk_max_bytes: int = 0,
+                 disk_dir: str | None = None):
         self._store: "OrderedDict[tuple, tuple]" = OrderedDict()  # key -> (payload, nbytes)
         self._total_bytes = 0
         self._headroom_frac = float(headroom_frac)
@@ -83,6 +92,21 @@ class FeatureCache:
         self._max_bytes = int(max_bytes)
         self.hits = 0
         self.misses = 0
+        # --- disk spillover: a second, larger LRU tier on disk ---
+        # RAM-evicted entries spill here (pickled) instead of being dropped, up to
+        # `disk_max_bytes` (0 = off). get() checks RAM then disk. This mainly helps
+        # FEs whose cacheable payload can't be compressed to a small form (e.g. an
+        # upsampling FE that emits full-resolution features), where per-slice
+        # payloads are large and few fit in RAM: reading one back from disk is far
+        # cheaper than recomputing it, so a stack too large for the RAM tier still
+        # benefits on the next iteration.
+        self._disk_max_bytes = int(disk_max_bytes)
+        self._disk_dir = disk_dir            # a caller dir, or a temp dir made lazily
+        self._owns_disk_dir = disk_dir is None
+        self._disk_store: "OrderedDict[tuple, tuple]" = OrderedDict()  # key -> (path, nbytes)
+        self._disk_bytes = 0
+        self._disk_seq = 0
+        self.disk_hits = 0
 
     # -- budget helpers ----------------------------------------------------
 
@@ -105,16 +129,24 @@ class FeatureCache:
     # -- public API --------------------------------------------------------
 
     def get(self, key):
-        """Return the cached payload for `key`, or None. Marks it most-recent."""
+        """Return the cached payload for `key`, or None. Checks RAM, then the disk
+        tier. A disk hit returns the loaded payload but leaves it on disk (no
+        promote-and-thrash): the RAM tier holds the most recent entries, disk the
+        older ones."""
         if not self.enabled:
             return None
         item = self._store.get(key)
-        if item is None:
-            self.misses += 1
-            return None
-        self._store.move_to_end(key)  # most-recently-used
-        self.hits += 1
-        return item[0]
+        if item is not None:
+            self._store.move_to_end(key)  # most-recently-used
+            self.hits += 1
+            return item[0]
+        payload = self._load_from_disk(key)  # RAM miss -> try disk
+        if payload is not None:
+            self.hits += 1
+            self.disk_hits += 1
+            return payload
+        self.misses += 1
+        return None
 
     def put(self, key, payload, nbytes: int | None = None):
         """Store `payload` under `key` if it fits the budget; else evict LRU and
@@ -139,38 +171,144 @@ class FeatureCache:
         self._total_bytes += nbytes
 
     def _evict_one(self):
-        _, (_, nbytes) = self._store.popitem(last=False)  # LRU = oldest
+        key, (payload, nbytes) = self._store.popitem(last=False)  # LRU = oldest
         self._total_bytes -= nbytes
+        # Spill to the disk tier instead of dropping (if disk spillover is on).
+        self._spill_to_disk(key, payload, nbytes)
+
+    # -- disk tier ---------------------------------------------------------
+
+    def _ensure_disk_dir(self) -> str:
+        if self._disk_dir is None:
+            self._disk_dir = tempfile.mkdtemp(prefix="convpaint_fcache_")
+            self._owns_disk_dir = True
+        os.makedirs(self._disk_dir, exist_ok=True)
+        return self._disk_dir
+
+    def _safe_remove(self, path):
+        try:
+            os.remove(path)
+        except OSError:
+            pass
+
+    def _remove_disk_entry(self, key):
+        item = self._disk_store.pop(key, None)
+        if item is not None:
+            path, nbytes = item
+            self._disk_bytes -= nbytes
+            self._safe_remove(path)
+
+    def _evict_disk_one(self):
+        key = next(iter(self._disk_store))  # LRU = oldest
+        self._remove_disk_entry(key)
+
+    def _spill_to_disk(self, key, payload, nbytes):
+        """Write an RAM-evicted payload to the disk tier (LRU-bounded). No-op if
+        disk spillover is off or the single payload exceeds the disk cap."""
+        if self._disk_max_bytes <= 0 or nbytes > self._disk_max_bytes:
+            return
+        self._remove_disk_entry(key)  # replace any stale copy
+        while self._disk_store and self._disk_bytes + nbytes > self._disk_max_bytes:
+            self._evict_disk_one()
+        if self._disk_bytes + nbytes > self._disk_max_bytes:
+            return
+        # Also never fill the actual filesystem below the free-space headroom.
+        try:
+            free = shutil.disk_usage(self._ensure_disk_dir()).free
+            if free - nbytes < _DISK_HEADROOM_BYTES:
+                return
+        except OSError:
+            pass
+        self._disk_seq += 1
+        path = os.path.join(self._ensure_disk_dir(), f"{self._disk_seq}.pkl")
+        try:
+            with open(path, "wb") as f:
+                pickle.dump(payload, f, protocol=pickle.HIGHEST_PROTOCOL)
+        except Exception:
+            self._safe_remove(path)
+            return
+        self._disk_store[key] = (path, nbytes)
+        self._disk_bytes += nbytes
+
+    def _load_from_disk(self, key):
+        item = self._disk_store.get(key)
+        if item is None:
+            return None
+        path, _ = item
+        try:
+            with open(path, "rb") as f:
+                payload = pickle.load(f)
+        except Exception:
+            self._remove_disk_entry(key)
+            return None
+        self._disk_store.move_to_end(key)  # mark recently used
+        return payload
+
+    def _clear_disk(self):
+        for path, _ in list(self._disk_store.values()):
+            self._safe_remove(path)
+        self._disk_store.clear()
+        self._disk_bytes = 0
+
+    # -- invalidation / limits --------------------------------------------
 
     def invalidate(self, predicate=None):
-        """Drop entries. With no predicate, clears everything; otherwise drops
-        keys for which `predicate(key)` is True (e.g. all entries of one img_id
-        when its data changed, or of a changed FE signature)."""
+        """Drop entries (both RAM and disk tiers). With no predicate, clears
+        everything; otherwise drops keys for which `predicate(key)` is True."""
         if predicate is None:
             self._store.clear()
             self._total_bytes = 0
+            self._clear_disk()
             return
         for key in [k for k in self._store if predicate(k)]:
             self._total_bytes -= self._store.pop(key)[1]
+        for key in [k for k in self._disk_store if predicate(k)]:
+            self._remove_disk_entry(key)
 
     def clear(self):
         self.invalidate(None)
 
     def set_max_bytes(self, max_bytes: int):
-        """Change the cap in place, evicting LRU entries if now over it."""
+        """Change the RAM cap in place, evicting (spilling) LRU entries if over."""
         self._max_bytes = int(max_bytes)
         while self._store and self._total_bytes > self._max_bytes:
             self._evict_one()
 
+    def set_disk_max_bytes(self, disk_max_bytes: int):
+        """Change the disk cap in place, evicting disk LRU if over (0 = off)."""
+        self._disk_max_bytes = int(disk_max_bytes)
+        if self._disk_max_bytes <= 0:
+            self._clear_disk()
+        else:
+            while self._disk_store and self._disk_bytes > self._disk_max_bytes:
+                self._evict_disk_one()
+
     def set_enabled(self, enabled: bool):
-        """Enable/disable in place; disabling clears the cache to free RAM."""
+        """Enable/disable in place; disabling clears both tiers to free space."""
         self.enabled = bool(enabled)
         if not self.enabled:
             self.clear()
 
+    def close(self):
+        """Free the disk tier and remove the temp directory this cache created."""
+        self._clear_disk()
+        if self._owns_disk_dir and self._disk_dir:
+            shutil.rmtree(self._disk_dir, ignore_errors=True)
+            self._disk_dir = None
+
+    def __del__(self):  # pragma: no cover - best-effort cleanup
+        try:
+            self.close()
+        except Exception:
+            pass
+
     @property
     def nbytes(self) -> int:
         return self._total_bytes
+
+    @property
+    def disk_nbytes(self) -> int:
+        return self._disk_bytes
 
     def __len__(self):
         return len(self._store)
@@ -180,6 +318,9 @@ class FeatureCache:
         return {
             "entries": len(self._store),
             "bytes": self._total_bytes,
+            "disk_entries": len(self._disk_store),
+            "disk_bytes": self._disk_bytes,
+            "disk_hits": self.disk_hits,
             "hits": self.hits,
             "misses": self.misses,
             "hit_rate": (self.hits / total) if total else 0.0,

--- a/src/napari_convpaint/feature_cache.py
+++ b/src/napari_convpaint/feature_cache.py
@@ -1,0 +1,187 @@
+"""Bounded, FE-pluggable feature cache for the interactive annotate→predict loop.
+
+The expensive step in interactive segmentation is feature extraction; when the
+same image (or z-slice / movie frame) is segmented repeatedly while refining
+scribbles, its features can be reused instead of recomputed. This module holds a
+generic, feature-extractor-agnostic cache: it stores an *opaque payload* defined
+by each FE (e.g. DINO patch tokens — tiny and lossless to upsample), keyed by
+`(img_id, slice, FE-signature)`, and owns everything storage-related — LRU
+eviction and, crucially, a memory budget so caching a 100-slice stack or a
+300-frame movie can never grow unbounded and crash the kernel.
+
+Triage principle (never OOM): before storing an entry, its size is checked
+against a live budget = `min(configured cap, available_RAM − headroom)`. If it
+does not fit, the least-recently-used entries are evicted; if it still does not
+fit (a single payload larger than the budget), it is simply not cached and the
+caller recomputes. The cache never exceeds the budget, so it degrades to
+recomputation rather than pushing the system into swap.
+
+FE-specific behaviour lives in the FeatureExtractor (see the `cacheable_repr` /
+`features_from_cacheable` / `cacheable_nbytes` / `supports_feature_cache`
+protocol on the base class): the cache never needs to know what is inside a
+payload.
+"""
+from __future__ import annotations
+
+from collections import OrderedDict
+
+try:
+    import psutil
+    _HAVE_PSUTIL = True
+except Exception:  # pragma: no cover - psutil is optional
+    _HAVE_PSUTIL = False
+
+
+# Fallback absolute cap when available-RAM cannot be queried (no psutil).
+_DEFAULT_MAX_BYTES = 2 * 1024 ** 3  # 2 GiB
+# Keep at least this fraction of currently-available RAM free (never consume it
+# all with cache), as a safety headroom against OOM.
+_DEFAULT_HEADROOM_FRAC = 0.25
+
+
+def _payload_nbytes(payload) -> int:
+    """Best-effort byte size of an opaque payload (array, list/tuple of arrays,
+    or anything exposing .nbytes). Unknown → 0 (treated as free, but such
+    payloads should provide a size via the FE's cacheable_nbytes)."""
+    if payload is None:
+        return 0
+    if hasattr(payload, "nbytes"):
+        return int(payload.nbytes)
+    if isinstance(payload, (list, tuple)):
+        return sum(_payload_nbytes(p) for p in payload)
+    return 0
+
+
+class FeatureCache:
+    """LRU feature cache bounded by a memory budget.
+
+    Parameters
+    ----------
+    max_bytes : int or None
+        Hard cap on the cache's own size. None → an automatic cap derived from
+        system RAM (a quarter of total, or `_DEFAULT_MAX_BYTES` without psutil).
+    headroom_frac : float
+        Fraction of *currently available* RAM to always keep free. The live
+        budget is `available_RAM * (1 - headroom_frac)`; entries are never added
+        (and are evicted) to respect it, so the cache cannot trigger OOM.
+    enabled : bool
+        Master switch; when False, get() always misses and put() is a no-op.
+    """
+
+    def __init__(self, max_bytes: int | None = None,
+                 headroom_frac: float = _DEFAULT_HEADROOM_FRAC,
+                 enabled: bool = True):
+        self._store: "OrderedDict[tuple, tuple]" = OrderedDict()  # key -> (payload, nbytes)
+        self._total_bytes = 0
+        self._headroom_frac = float(headroom_frac)
+        self.enabled = bool(enabled)
+        if max_bytes is None:
+            if _HAVE_PSUTIL:
+                max_bytes = int(psutil.virtual_memory().total * 0.25)
+            else:
+                max_bytes = _DEFAULT_MAX_BYTES
+        self._max_bytes = int(max_bytes)
+        self.hits = 0
+        self.misses = 0
+
+    # -- budget helpers ----------------------------------------------------
+
+    def _available_bytes(self) -> int:
+        if _HAVE_PSUTIL:
+            return int(psutil.virtual_memory().available)
+        # No psutil: rely solely on the configured cap (assume plenty free).
+        return self._max_bytes
+
+    def _fits(self, nbytes: int) -> bool:
+        """Whether adding `nbytes` keeps the cache under its cap AND leaves the
+        configured headroom of currently-available RAM free."""
+        if self._total_bytes + nbytes > self._max_bytes:
+            return False
+        # available RAM already accounts for the cache's current allocation, so
+        # only the *new* bytes reduce it further.
+        avail_after = self._available_bytes() - nbytes
+        return avail_after >= self._headroom_frac * self._available_bytes()
+
+    # -- public API --------------------------------------------------------
+
+    def get(self, key):
+        """Return the cached payload for `key`, or None. Marks it most-recent."""
+        if not self.enabled:
+            return None
+        item = self._store.get(key)
+        if item is None:
+            self.misses += 1
+            return None
+        self._store.move_to_end(key)  # most-recently-used
+        self.hits += 1
+        return item[0]
+
+    def put(self, key, payload, nbytes: int | None = None):
+        """Store `payload` under `key` if it fits the budget; else evict LRU and
+        retry, and if it still does not fit, skip caching (caller recomputes)."""
+        if not self.enabled or payload is None:
+            return
+        if nbytes is None:
+            nbytes = _payload_nbytes(payload)
+        # A single payload larger than the whole cap can never be cached safely.
+        if nbytes > self._max_bytes:
+            return
+        # Overwrite of an existing key: drop the old size first.
+        if key in self._store:
+            self._total_bytes -= self._store.pop(key)[1]
+        # Evict least-recently-used until the new entry fits.
+        while self._store and not self._fits(nbytes):
+            self._evict_one()
+        if not self._fits(nbytes):
+            return  # even empty it doesn't fit the live headroom → don't cache
+        self._store[key] = (payload, nbytes)
+        self._store.move_to_end(key)
+        self._total_bytes += nbytes
+
+    def _evict_one(self):
+        _, (_, nbytes) = self._store.popitem(last=False)  # LRU = oldest
+        self._total_bytes -= nbytes
+
+    def invalidate(self, predicate=None):
+        """Drop entries. With no predicate, clears everything; otherwise drops
+        keys for which `predicate(key)` is True (e.g. all entries of one img_id
+        when its data changed, or of a changed FE signature)."""
+        if predicate is None:
+            self._store.clear()
+            self._total_bytes = 0
+            return
+        for key in [k for k in self._store if predicate(k)]:
+            self._total_bytes -= self._store.pop(key)[1]
+
+    def clear(self):
+        self.invalidate(None)
+
+    def set_max_bytes(self, max_bytes: int):
+        """Change the cap in place, evicting LRU entries if now over it."""
+        self._max_bytes = int(max_bytes)
+        while self._store and self._total_bytes > self._max_bytes:
+            self._evict_one()
+
+    def set_enabled(self, enabled: bool):
+        """Enable/disable in place; disabling clears the cache to free RAM."""
+        self.enabled = bool(enabled)
+        if not self.enabled:
+            self.clear()
+
+    @property
+    def nbytes(self) -> int:
+        return self._total_bytes
+
+    def __len__(self):
+        return len(self._store)
+
+    def stats(self) -> dict:
+        total = self.hits + self.misses
+        return {
+            "entries": len(self._store),
+            "bytes": self._total_bytes,
+            "hits": self.hits,
+            "misses": self.misses,
+            "hit_rate": (self.hits / total) if total else 0.0,
+            "max_bytes": self._max_bytes,
+        }

--- a/src/napari_convpaint/feature_extractor.py
+++ b/src/napari_convpaint/feature_extractor.py
@@ -362,21 +362,32 @@ class FeatureExtractor:
             The extracted features of the image as a single array with [nb_features, Z, H, W]
         """
 
-        features_all_scales = []
+        native = self._pyramid_native(data, param, device)
+        return self._pyramid_reconstruct(native, data.shape, param, patched)
 
+    def _pyramid_native(self, data, param, device=torch.device("cpu")):
+        """Expensive half of the pyramid: extract the per-scale *native*
+        (pre-rescale) features. Returns a payload — one entry per scale of
+        ``(features_list, pre_reduction_shape, reduced_shape)`` with the features
+        as CPU numpy arrays — that ``_pyramid_reconstruct`` turns into the final
+        feature stack.
+
+        This is the cacheable representation: it is independent of the requested
+        output resolution (``patched``), and for patched FEs (ViTs) it is the
+        small patch-grid features rather than the full-resolution stack. See the
+        feature-cache protocol below (``cacheable_repr``)."""
         # Check if the given selection of scalings is in the proposed scalings, and if not, give a warning
         if not param.fe_scalings in self.get_proposed_scalings():
             warnings.warn(f"The selected scalings {param.fe_scalings} are not in the proposed scalings {self.proposed_scalings}. Please check if this is intentional.")
 
-        # Iterate over the scales and extract features for each scale
+        native = []
         for s in param.fe_scalings:
-
             # Downscale the image
             image_scaled = scale_img(data, s)
 
             # Make sure the downscaled part is a multiple of the patch size
             patch_size = self.get_patch_size()
-            pre_reduction_shape  = image_scaled.shape
+            pre_reduction_shape = image_scaled.shape
             # NOTE: reduce_to_patch_multiple should not do anything if the inputs are already multiples of the patch size at all scales
             image_scaled = reduce_to_patch_multiple(image_scaled, patch_size)
             reduced_shape = image_scaled.shape
@@ -388,14 +399,28 @@ class FeatureExtractor:
             # In case the features are not a list, but a single array, make it a list
             if not isinstance(features, list):
                 features = [features]
+            # Convert any torch tensors to CPU numpy so the payload is
+            # device-independent and safe to cache.
+            features = [f.detach().cpu().numpy() if isinstance(f, torch.Tensor) else f
+                        for f in features]
+            native.append((features, pre_reduction_shape, reduced_shape))
+        return native
 
+    def _pyramid_reconstruct(self, native, data_shape, param, patched=True):
+        """Cheap half of the pyramid: rescale the native per-scale features to the
+        requested resolution and concatenate across channel-series and scales.
+        ``native`` is the payload from ``_pyramid_native``; ``data_shape`` is the
+        original (pre-scaling) input shape [C, Z, H, W]."""
+        patch_size = self.get_patch_size()
+        features_all_scales = []
+        for features, pre_reduction_shape, reduced_shape in native:
             # Resize the features from this downscaling to the size of the (possibly patched) input
             # NOTE: this shouldn't do anything for scaling of 1, unless we want to "unpatch"
             if patched:
-                target_shape = (data.shape[0],
-                                data.shape[1],
-                                data.shape[2]//self.get_patch_size(),
-                                data.shape[3]//self.get_patch_size())
+                target_shape = (data_shape[0],
+                                data_shape[1],
+                                data_shape[2]//patch_size,
+                                data_shape[3]//patch_size)
             else:
                 # When not patched, but patch_size > 1, we handle possible cropping due to reduce_to_patch_multiple
                 # NOTE: this should not be necessary if the inputs are already multiples of the patch size at all scales
@@ -411,7 +436,7 @@ class FeatureExtractor:
                     features = [pad_to_shape(f, pre_reduction_shape[2:] ) for f in features]
 
                 # Rescale to the full original shape
-                target_shape = data.shape
+                target_shape = data_shape
 
             features = [rescale_features(
                                 feature_img=f,
@@ -419,11 +444,6 @@ class FeatureExtractor:
                                 order=param.fe_order)
                         for f in features]
 
-            # If torch tensor is returned, convert to numpy array
-            if isinstance(features[0], torch.Tensor):
-                # Detach, move to cpu, make np array
-                features = [feature.detach().cpu().numpy() for feature in features]
-            
             # Put together features for each input_channels procession (and layers if applicable)
             features = np.concatenate(features, axis=0)
 
@@ -437,11 +457,39 @@ class FeatureExtractor:
 
             # Add the features to the list of features
             features_all_scales.append(features)
-        
+
         # Concatenate the features from all scales along the first axis
         features_all_scales = np.concatenate(features_all_scales, axis=0)
 
         return features_all_scales
+
+### FEATURE CACHING PROTOCOL (optional per-FE optimization; see feature_cache.py)
+
+    def supports_feature_cache(self, param):
+        """Whether whole-image feature caching is worthwhile for this FE. FEs that
+        are cheap to recompute or whose extraction doesn't fit the pyramid split
+        can return False to opt out."""
+        return True
+
+    def cacheable_repr(self, data, param, device=torch.device("cpu")):
+        """Compute the cacheable payload for `data`: the expensive, ideally-small
+        intermediate that `features_from_cacheable` turns into full features.
+        Default = the pre-rescale native pyramid features (patch tokens for ViTs,
+        per-scale maps for CNNs), which are resolution-independent so one cached
+        payload serves both training (unpatched) and prediction (patched)."""
+        return self._pyramid_native(data, param, device)
+
+    def features_from_cacheable(self, payload, data_shape, param, patched=True):
+        """Reconstruct the features the pipeline needs from a cached payload."""
+        return self._pyramid_reconstruct(payload, data_shape, param, patched)
+
+    def cacheable_nbytes(self, payload):
+        """Byte size of a payload from `cacheable_repr`, for the cache budget."""
+        total = 0
+        for features, _, _ in payload:
+            for f in features:
+                total += getattr(f, "nbytes", 0)
+        return total
 
     def extract_features_from_multichannel_stack(self, image, rgb_data=False, device=torch.device("cpu")):
         """

--- a/src/napari_convpaint/feature_extractor.py
+++ b/src/napari_convpaint/feature_extractor.py
@@ -478,6 +478,15 @@ class FeatureExtractor:
         RAM but are dropped instead of pickled to disk."""
         return True
 
+    def cache_extra_state(self, param):
+        """Extraction-relevant state that lives on the FE instance rather than in
+        `param`, to be mixed into the feature-cache key. Any FE whose output
+        depends on constructor/instance state (e.g. sigmas, scalings moved out of
+        the Param by `get_enforced_params`) must return it here, or stale cached
+        features will be served after that state changes. Return value must be
+        hashable (or None)."""
+        return None
+
     def cacheable_repr(self, data, param, device=torch.device("cpu")):
         """Compute the cacheable payload for `data`: the expensive, ideally-small
         intermediate that `features_from_cacheable` turns into full features.

--- a/src/napari_convpaint/feature_extractor.py
+++ b/src/napari_convpaint/feature_extractor.py
@@ -30,6 +30,11 @@ class FeatureExtractor:
         # For such FEs, tile_annotations / tile_image cannot match whole-image features at any finite padding
         self.tile_block_size = None # If not None, this block size is used for tiling the image at segmentation
         self.num_input_channels = [1]
+        # Number of features each hooked layer contributes (only Hookmodel sets a
+        # real value); default None so `fe_use_min_features` degrades gracefully
+        # (warns and uses all features) for FEs that don't track it, instead of
+        # raising AttributeError.
+        self.features_per_layer = None
         self.norm_mode = "default"  # or "imagenet" or "percentile"
         self.rgb_input = False # Whether the model takes RGB input or not
         self.proposed_scalings = [[1],
@@ -292,7 +297,7 @@ class FeatureExtractor:
             The list of devices that the feature extractor supports.
         """
         if self.model is not None and hasattr(self.model, "to"):
-            return [torch.device("cuda"), torch.device("mps"), [torch.device("cpu")]]
+            return [torch.device("cuda"), torch.device("mps"), torch.device("cpu")]
         else:
             return [torch.device("cpu")]
 

--- a/src/napari_convpaint/feature_extractor.py
+++ b/src/napari_convpaint/feature_extractor.py
@@ -471,6 +471,13 @@ class FeatureExtractor:
         can return False to opt out."""
         return True
 
+    def cache_spill_to_disk(self):
+        """Whether this FE's payloads may be spilled to the disk cache tier on
+        RAM eviction. FEs whose payloads are huge relative to their recompute
+        cost (e.g. CNN feature maps) should return False: they stay cacheable in
+        RAM but are dropped instead of pickled to disk."""
+        return True
+
     def cacheable_repr(self, data, param, device=torch.device("cpu")):
         """Compute the cacheable payload for `data`: the expensive, ideally-small
         intermediate that `features_from_cacheable` turns into full features.

--- a/src/napari_convpaint/feature_extractors/cellpose.py
+++ b/src/napari_convpaint/feature_extractors/cellpose.py
@@ -3,6 +3,7 @@ import torch
 import numpy as np
 import skimage
 import importlib.util
+from .. import utils
 from ..utils import get_device_from_torch_model
 
 def import_models():
@@ -158,23 +159,20 @@ class CellposeFeatures(FeatureExtractor):
         for t in T0[:3]:
             # Put to cpu, detach, and convert to numpy
             t = t.detach().cpu().numpy()[0]
-            # Resize if necessary
+            # Resize if necessary (upsample the downsampled feature maps to image
+            # resolution). resize_nearest is bit-identical to the previous
+            # skimage.transform.resize(order=0) here but far faster on the
+            # many-channel feature tensors (skimage is per-channel single-threaded).
             f,w,h = t.shape[-3:]
             if (w,h) != (w_img,h_img):
-                t = skimage.transform.resize(
-                        image=t,
-                        output_shape=(f, w_img, h_img),
-                        preserve_range=True, order=0)
+                t = utils.resize_nearest(t, (w_img, h_img))
             out_t.append(t)
 
         #append the output tensor from T1 (gradients and cell probability)
         t = T1.detach().cpu().numpy()[0]
         f,w,h = t.shape[-3:]
         if (w,h) != (w_img,h_img):
-            t = skimage.transform.resize(
-                    image=t,
-                    output_shape=(f, w_img, h_img),
-                    preserve_range=True, order=0)
+            t = utils.resize_nearest(t, (w_img, h_img))
         out_t.append(t)
 
         #append the original image

--- a/src/napari_convpaint/feature_extractors/combo_fe.py
+++ b/src/napari_convpaint/feature_extractors/combo_fe.py
@@ -109,6 +109,12 @@ class ComboFeatures(FeatureExtractor):
         # So, the combo FE itself is not patched, even if it works with a patch_size to comply with the models
         return False
 
+    def supports_feature_cache(self, param):
+        # ComboFeatures overrides extract_features_pyramid to combine two sub-FEs,
+        # so it does not go through the base _pyramid_native/_pyramid_reconstruct
+        # split the cache relies on. Opt out of caching for now (v1).
+        return False
+
     def extract_features_pyramid(self, data, param, patched=False, device=None):
         # NOTE: each sub-FE runs with ITS OWN default scalings/order
         # (get_default_params overrides fe_scalings/fe_order), not the combo-level

--- a/src/napari_convpaint/feature_extractors/combo_fe.py
+++ b/src/napari_convpaint/feature_extractors/combo_fe.py
@@ -109,10 +109,16 @@ class ComboFeatures(FeatureExtractor):
         # So, the combo FE itself is not patched, even if it works with a patch_size to comply with the models
         return False
 
-    def extract_features_pyramid(self, image, param, patched=False, device=None):
+    def extract_features_pyramid(self, data, param, patched=False, device=None):
+        # NOTE: each sub-FE runs with ITS OWN default scalings/order
+        # (get_default_params overrides fe_scalings/fe_order), not the combo-level
+        # ones. This is intentional: the sub-FEs are heterogeneous (e.g. a ViT
+        # that only supports scalings [1] combined with a CNN pyramid), so a
+        # single user-chosen scaling set cannot apply to both. Both halves are
+        # always unpatched (patched=False) and concatenated on the feature axis.
         def1 = self.model1.get_default_params(param)
-        features1 = self.model1.extract_features_pyramid(image, def1, patched=False, device=device)
+        features1 = self.model1.extract_features_pyramid(data, def1, patched=False, device=device)
         def2 = self.model2.get_default_params(param)
-        features2 = self.model2.extract_features_pyramid(image, def2, patched=False, device=device)
+        features2 = self.model2.extract_features_pyramid(data, def2, patched=False, device=device)
         features = np.concatenate((features1, features2), axis=0)
         return features

--- a/src/napari_convpaint/feature_extractors/dino_jafar.py
+++ b/src/napari_convpaint/feature_extractors/dino_jafar.py
@@ -78,12 +78,21 @@ class DinoJafarFeatures(FeatureExtractor):
         self.num_input_channels = [3]           # RGB
         self.norm_mode = "imagenet"
         self.rgb_input = True
+        # DINO ViT backbone: attention mixes the whole image into every token,
+        # so features are global — tiling cannot reproduce whole-image features.
+        self.has_global_context = True
         # The largest scale equals the backbone patch size — at that scale
         # JAFAR is asked for native patch-resolution output (no upsampling).
         self.proposed_scalings = [[1],
                                   [1, 8],
                                   [1, 8, self.patch_size],
                                   ]
+
+        # Internal JAFAR upsampling scales; normally (re)set from fe_scalings in
+        # get_enforced_params before extraction, but default it here so direct FE
+        # use (extract_features_from_plane without going through ConvpaintModel)
+        # doesn't hit an AttributeError.
+        self.jafar_scalings = [1]
 
         # Parent .create_model() saves tuple (hr_head, backbone) in self.model
         self.model, self.backbone = self.model
@@ -261,11 +270,15 @@ class DinoJafarFeatures(FeatureExtractor):
         else:
             tile_px = min(desired_tile_px, max_fit)
 
-        # Ensure overlap_tokens yields positive stride
-        # stride = tile_px - overlap_tokens*ps
-        max_overlap_tokens = (tile_px // ps) - 1  # need at least one stride
-        if max_overlap_tokens < 0:
-            max_overlap_tokens = 0
+        # Clamp overlap_tokens to satisfy BOTH constraints:
+        #  - positive stride:            tile_px - overlap*ps > 0  -> overlap <= tiles-1
+        #  - non-negative blend window:  tile_px - 2*overlap*ps >= 0 -> overlap <= tiles//2
+        # The window builder (_extract_tiled_multiscale) makes a symmetric
+        # ramp/flat/ramp of length tile_px - 2*overlap*ps; without the second
+        # bound, a tile exactly 3 patches wide (tiles==3, overlap==2) passes the
+        # stride check but requests torch.ones(-ps) and crashes.
+        tiles = tile_px // ps
+        max_overlap_tokens = max(0, min(tiles - 1, tiles // 2))
         if overlap_tokens > max_overlap_tokens:
             overlap_tokens = max_overlap_tokens
 
@@ -307,8 +320,10 @@ class DinoJafarFeatures(FeatureExtractor):
         stride = tile_px - ov_px
         assert stride > 0, "Invalid stride (overlap too large)."
 
-        # A CPU copy of the hr_head is kept for device-incompatible runtime errors
-        hr_head_cpu = copy.deepcopy(hr_head).to("cpu").eval()
+        # A CPU copy of the hr_head is only needed if a device (e.g. MPS) error
+        # forces a CPU retry — build it lazily on first use instead of deep-copying
+        # the whole head on every extraction call (this method runs once per plane).
+        hr_head_cpu = None
 
         # Get low-resolution backbone features for the full image once
         lr_full, _ = backbone(image_batch)
@@ -363,8 +378,11 @@ class DinoJafarFeatures(FeatureExtractor):
                             feat = hr_head(img_tile, lr_tile, (out_h, out_h))
                         except RuntimeError as e:
                             # Some devices (MPS) or dtype mismatches may fail;
-                            # retry on the CPU copy and move back to runtime device.
+                            # retry on the CPU copy (built once, on demand) and
+                            # move back to the runtime device.
                             if "MPS" in str(e) or "weight type" in str(e):
+                                if hr_head_cpu is None:
+                                    hr_head_cpu = copy.deepcopy(hr_head).to("cpu").eval()
                                 feat = hr_head_cpu(img_tile.cpu(), lr_tile.cpu(), (out_h, out_h)).to(dev)
                             else:
                                 raise
@@ -395,10 +413,14 @@ class DinoJafarFeatures(FeatureExtractor):
                     # Track the blending weights used for normalization
                     weight_cpu[:, :, top:top + tile_px, left:left + tile_px] += w2d.cpu()
 
-                    # Free temporary locals and clear MPS cache if available
+                    # Free temporary locals
                     del img_tile, lr_tile, per_scale_feats, feat_cat, chunks, weighted
-                    if torch.backends.mps.is_available():
-                        torch.mps.empty_cache()  # avoid MPS fragmentation issues
+
+            # Clear the MPS cache once per plane (after all tiles), not per tile:
+            # torch.mps.empty_cache() forces a device sync, so calling it inside
+            # the tile loop serialized the GPU and dominated runtime.
+            if torch.backends.mps.is_available():
+                torch.mps.empty_cache()
 
         # Normalize accumulated sums by weights and concatenate per-scale results
         eps = 1e-8

--- a/src/napari_convpaint/feature_extractors/dino_jafar.py
+++ b/src/napari_convpaint/feature_extractors/dino_jafar.py
@@ -179,6 +179,13 @@ class DinoJafarFeatures(FeatureExtractor):
             #param.fe_scalings = [4]
         return param
 
+    def cache_extra_state(self, param):
+        # The user's fe_scalings are moved out of the Param (forced to [1]) into
+        # self.jafar_scalings by get_enforced_params, and the cached payload
+        # bakes them in — so they must be part of the cache key or changing the
+        # scalings would silently serve stale features.
+        return ("jafar_scalings", tuple(self.jafar_scalings))
+
     # ------------------------------------------------------------------ #
     # Public extraction entry points
     # ------------------------------------------------------------------ #

--- a/src/napari_convpaint/feature_extractors/dinov3.py
+++ b/src/napari_convpaint/feature_extractors/dinov3.py
@@ -50,6 +50,10 @@ class Dinov3Features(FeatureExtractor):
         self.num_input_channels = [3]
         self.norm_mode = "imagenet"
         self.rgb_input = True
+        # ViT self-attention mixes information across the whole image, so a
+        # pixel's features depend on the entire input — tiling cannot reproduce
+        # whole-image features (matches DINOv2 in dino.py).
+        self.has_global_context = True
         self.proposed_scalings = [[1]]
 
         # CLS + register tokens prefix the patch tokens in forward_features output

--- a/src/napari_convpaint/feature_extractors/gaussian.py
+++ b/src/napari_convpaint/feature_extractors/gaussian.py
@@ -27,6 +27,11 @@ class GaussianFeatures(FeatureExtractor):
         param.fe_layers = None
         return param
 
+    def cache_extra_state(self, param):
+        # sigma lives on the instance, not the Param — it must enter the cache
+        # key or a model rebuilt with a different sigma could hit stale entries.
+        return ("sigma", self.sigma)
+
     def extract_features_from_plane(self, image, device=None):
         
         # Given that we get single-channel images as input:

--- a/src/napari_convpaint/feature_extractors/nnlayers.py
+++ b/src/napari_convpaint/feature_extractors/nnlayers.py
@@ -230,7 +230,12 @@ class Hookmodel(FeatureExtractor):
         no finite padding makes tile features match whole-image features.
         """
         if len(self.selected_layers) == 0:
-            return 1, False
+            # Neutral defaults — without this, a re-hook with an empty selection
+            # would silently keep the previous selection's values.
+            self.padding = 0
+            self.patch_size = 1
+            self.has_global_context = False
+            return
         rf = 1
         stride = 1
         has_global = False

--- a/src/napari_convpaint/feature_extractors/nnlayers.py
+++ b/src/napari_convpaint/feature_extractors/nnlayers.py
@@ -265,6 +265,25 @@ class Hookmodel(FeatureExtractor):
     def get_num_input_channels(self):
         return [self.named_modules[0][1].in_channels]
     
+    def __getstate__(self):
+        # threading.local and torch hook handles cannot be pickled (dask
+        # serializes the model when tiles are submitted, even on a threaded
+        # cluster). Drop both and rebuild the hooks on unpickle.
+        state = self.__dict__.copy()
+        state.pop('_tls', None)
+        state.pop('_hook_handles', None)
+        return state
+
+    def __setstate__(self, state):
+        self.__dict__.update(state)
+        self._tls = threading.local()
+        self._hook_handles = []
+        # Hooks captured inside the pickled torch modules can't be removed
+        # without their handles — clear them and re-register cleanly.
+        for module in self.module_dict.values():
+            module._forward_hooks.clear()
+        self.register_hooks(self.selected_layers)
+
     def _thread_outputs(self):
         """Per-thread list the forward hooks append captured features into."""
         outputs = getattr(self._tls, "outputs", None)

--- a/src/napari_convpaint/feature_extractors/nnlayers.py
+++ b/src/napari_convpaint/feature_extractors/nnlayers.py
@@ -1,4 +1,3 @@
-import threading
 import numpy as np
 import torch
 from torch import nn
@@ -85,11 +84,7 @@ class Hookmodel(FeatureExtractor):
         # INITIALIZATION OF LAYER HOOKS
         self.init_layer_dict()
 
-        # Hook outputs are kept per-thread: the forward hooks append captured
-        # feature maps into a thread-local list so concurrent extractions (e.g.
-        # the threaded dask prediction path, which shares this one FE instance
-        # across worker threads) do not clobber each other's outputs.
-        self._tls = threading.local()
+        self.outputs = []
         # Handles for the registered forward hooks, so they can be removed before
         # re-registering (otherwise a stale hook_last keeps aborting the forward).
         self._hook_handles = []
@@ -265,41 +260,14 @@ class Hookmodel(FeatureExtractor):
     def get_num_input_channels(self):
         return [self.named_modules[0][1].in_channels]
     
-    def __getstate__(self):
-        # threading.local and torch hook handles cannot be pickled (dask
-        # serializes the model when tiles are submitted, even on a threaded
-        # cluster). Drop both and rebuild the hooks on unpickle.
-        state = self.__dict__.copy()
-        state.pop('_tls', None)
-        state.pop('_hook_handles', None)
-        return state
-
-    def __setstate__(self, state):
-        self.__dict__.update(state)
-        self._tls = threading.local()
-        self._hook_handles = []
-        # Hooks captured inside the pickled torch modules can't be removed
-        # without their handles — clear them and re-register cleanly.
-        for module in self.module_dict.values():
-            module._forward_hooks.clear()
-        self.register_hooks(self.selected_layers)
-
-    def _thread_outputs(self):
-        """Per-thread list the forward hooks append captured features into."""
-        outputs = getattr(self._tls, "outputs", None)
-        if outputs is None:
-            outputs = []
-            self._tls.outputs = outputs
-        return outputs
-
     def extract_features_from_stack(self, image, device=torch.device("cpu")):
         self.move_model_to_device(device)
 
         # Convert image to numpy array and ensure correct data type
         image = np.asarray(image, dtype=np.float32)
 
-        # Fresh per-thread output list for this extraction (see __init__).
-        self._tls.outputs = []
+        # Fresh output list for this extraction (filled by the forward hooks).
+        self.outputs = []
         with torch.no_grad():
             # Treat z as batch dimension (temprorarily)
             ch_torch = torch.tensor(np.moveaxis(image, 1, 0))
@@ -311,7 +279,7 @@ class Hookmodel(FeatureExtractor):
                 raise ex
 
         # Move the z dimension back to the second position (and features to first)
-        outputs = [o.permute(1, 0, 2, 3) for o in self._tls.outputs]
+        outputs = [o.permute(1, 0, 2, 3) for o in self.outputs]
 
         return outputs
 
@@ -320,10 +288,10 @@ class Hookmodel(FeatureExtractor):
         return self.model(tensor_image_dev)
 
     def hook_normal(self, module, input, output):
-        self._thread_outputs().append(output)
+        self.outputs.append(output)
 
     def hook_last(self, module, input, output):
-        self._thread_outputs().append(output)
+        self.outputs.append(output)
         raise _StopForward
 
     def register_hooks(self, selected_layers):  # , selected_layer_pos):

--- a/src/napari_convpaint/feature_extractors/nnlayers.py
+++ b/src/napari_convpaint/feature_extractors/nnlayers.py
@@ -201,6 +201,12 @@ class Hookmodel(FeatureExtractor):
         # So we return False here, even if the patch size is >1.
         return False
 
+    def cache_spill_to_disk(self):
+        # CNN native payloads are per-pixel multi-scale feature maps — often
+        # hundreds of MB per slice, far more than the recompute cost justifies
+        # pickling to disk. Keep them RAM-cacheable only.
+        return False
+
     def _compute_nn_properties(self):
         """Walk the network in execution order, accumulating receptive field,
         total stride, and whether any global-context op was encountered, up to

--- a/src/napari_convpaint/feature_extractors/nnlayers.py
+++ b/src/napari_convpaint/feature_extractors/nnlayers.py
@@ -1,7 +1,16 @@
+import threading
 import numpy as np
 import torch
 from torch import nn
 from ..utils import get_device_from_torch_model, guided_model_download
+
+class _StopForward(Exception):
+    """Raised by the last hooked layer to abort the forward pass once all
+    selected features have been captured. A real exception (not `assert False`)
+    so that stopping still works under `python -O` / PYTHONOPTIMIZE, which strips
+    assert statements and would otherwise run the whole network every plane."""
+    pass
+
 
 def import_models():
     try:
@@ -76,7 +85,14 @@ class Hookmodel(FeatureExtractor):
         # INITIALIZATION OF LAYER HOOKS
         self.init_layer_dict()
 
-        self.outputs = []
+        # Hook outputs are kept per-thread: the forward hooks append captured
+        # feature maps into a thread-local list so concurrent extractions (e.g.
+        # the threaded dask prediction path, which shares this one FE instance
+        # across worker threads) do not clobber each other's outputs.
+        self._tls = threading.local()
+        # Handles for the registered forward hooks, so they can be removed before
+        # re-registering (otherwise a stale hook_last keeps aborting the forward).
+        self._hook_handles = []
         if layers is not None:
             self.register_hooks(layers)
         else:
@@ -238,25 +254,34 @@ class Hookmodel(FeatureExtractor):
     def get_num_input_channels(self):
         return [self.named_modules[0][1].in_channels]
     
+    def _thread_outputs(self):
+        """Per-thread list the forward hooks append captured features into."""
+        outputs = getattr(self._tls, "outputs", None)
+        if outputs is None:
+            outputs = []
+            self._tls.outputs = outputs
+        return outputs
+
     def extract_features_from_stack(self, image, device=torch.device("cpu")):
         self.move_model_to_device(device)
 
         # Convert image to numpy array and ensure correct data type
         image = np.asarray(image, dtype=np.float32)
 
-        self.outputs = []
+        # Fresh per-thread output list for this extraction (see __init__).
+        self._tls.outputs = []
         with torch.no_grad():
             # Treat z as batch dimension (temprorarily)
             ch_torch = torch.tensor(np.moveaxis(image, 1, 0))
             try:
                 _ = self(ch_torch) # Forward pass through the model
-            except AssertionError as ea:
-                pass # Stop at hook
+            except _StopForward:
+                pass # Stopped at the last hooked layer (all features captured)
             except Exception as ex:
                 raise ex
-            
+
         # Move the z dimension back to the second position (and features to first)
-        outputs = [o.permute(1, 0, 2, 3) for o in self.outputs]
+        outputs = [o.permute(1, 0, 2, 3) for o in self._tls.outputs]
 
         return outputs
 
@@ -265,25 +290,37 @@ class Hookmodel(FeatureExtractor):
         return self.model(tensor_image_dev)
 
     def hook_normal(self, module, input, output):
-        # print("extracting with normal layer")
-        self.outputs.append(output)
+        self._thread_outputs().append(output)
 
     def hook_last(self, module, input, output):
-        # print("extracting with last layer")
-        self.outputs.append(output)
-        assert False
+        self._thread_outputs().append(output)
+        raise _StopForward
 
     def register_hooks(self, selected_layers):  # , selected_layer_pos):
         selected_layers = self.layers_to_keys(selected_layers)
+        # Remove any previously registered hooks first — register_hooks is a
+        # public API and can be re-called on an existing instance; leaving the
+        # old hooks attached (in particular the old hook_last, which aborts the
+        # forward via `assert False`) would fire before the newly selected
+        # layers are reached and silently drop their features.
+        for handle in self._hook_handles:
+            handle.remove()
+        self._hook_handles = []
+        # Sort the selected layers into model execution order (module_dict is
+        # insertion-ordered = execution order). hook_last (which aborts the
+        # forward) must sit on the deepest-executing layer, and features must be
+        # captured in a consistent order; a caller passing layers out of order
+        # would otherwise abort early and silently drop the deeper layers.
+        module_order = {k: i for i, k in enumerate(self.module_dict.keys())}
+        selected_layers = sorted(selected_layers, key=lambda k: module_order.get(k, len(module_order)))
         self.features_per_layer = []
         self.selected_layers = selected_layers.copy()
         for ind in range(len(selected_layers)):
             self.features_per_layer.append(
                 self.module_dict[selected_layers[ind]].out_channels)
             if ind == len(selected_layers) - 1:
-                # print(f"registering LAST hook for layer {selected_layers[ind]}")
-                self.module_dict[selected_layers[ind]].register_forward_hook(self.hook_last)
+                handle = self.module_dict[selected_layers[ind]].register_forward_hook(self.hook_last)
             else:
-                # print(f"registering hook for layer {selected_layers[ind]}")
-                self.module_dict[selected_layers[ind]].register_forward_hook(self.hook_normal)
+                handle = self.module_dict[selected_layers[ind]].register_forward_hook(self.hook_normal)
+            self._hook_handles.append(handle)
         self._compute_nn_properties() # Recompute RF, patch size, and global context properties based on the new layers

--- a/src/napari_convpaint/param.py
+++ b/src/napari_convpaint/param.py
@@ -58,6 +58,11 @@ class Param:
         Learning rate for the classifier
     clf_depth : int
         Depth of the classifier
+    feature_semantics : int
+        Version of the feature-computation semantics the model was saved with
+        (stamped on save). Bumped when normalization/downscaling change the
+        numerical feature values, so loading warns that a classifier trained
+        under older semantics should be retrained.
     """
     classifier: str = None
 
@@ -86,6 +91,9 @@ class Param:
     clf_learning_rate: float = None
     clf_depth: int = None
     clf_use_gpu: bool = None # LEAVE THIS FOR NOW, FOR BACKWARDS COMPATIBILITY, BUT THIS SHOULD BE DEPRECATED EVENTUALLY
+
+    # Version of the feature-computation semantics (see docstring); stamped on save.
+    feature_semantics: int = None
     
     def get(self, key):
         """

--- a/src/napari_convpaint/param.py
+++ b/src/napari_convpaint/param.py
@@ -58,11 +58,6 @@ class Param:
         Learning rate for the classifier
     clf_depth : int
         Depth of the classifier
-    feature_semantics : int
-        Version of the feature-computation semantics the model was saved with
-        (stamped on save). Bumped when normalization/downscaling change the
-        numerical feature values, so loading warns that a classifier trained
-        under older semantics should be retrained.
     """
     classifier: str = None
 
@@ -92,9 +87,6 @@ class Param:
     clf_depth: int = None
     clf_use_gpu: bool = None # LEAVE THIS FOR NOW, FOR BACKWARDS COMPATIBILITY, BUT THIS SHOULD BE DEPRECATED EVENTUALLY
 
-    # Version of the feature-computation semantics (see docstring); stamped on save.
-    feature_semantics: int = None
-    
     def get(self, key):
         """
         Get the value of a parameter.

--- a/src/napari_convpaint/param.py
+++ b/src/napari_convpaint/param.py
@@ -86,7 +86,7 @@ class Param:
     clf_learning_rate: float = None
     clf_depth: int = None
     clf_use_gpu: bool = None # LEAVE THIS FOR NOW, FOR BACKWARDS COMPATIBILITY, BUT THIS SHOULD BE DEPRECATED EVENTUALLY
-
+    
     def get(self, key):
         """
         Get the value of a parameter.

--- a/src/napari_convpaint/utils.py
+++ b/src/napari_convpaint/utils.py
@@ -1,7 +1,6 @@
 import warnings
 import torch
 import numpy as np
-from scipy.ndimage import gaussian_filter
 from skimage.measure import block_reduce
 import skimage.transform
 import skimage.morphology as morph
@@ -192,9 +191,7 @@ def scale_img(image, scaling_factor, upscale=False, input_type="img"):
         If True, upscale the image by repeating the pixels.
     input_type : str ("img", "labels", "coords")
         Type of the input image. Determines how to scale the image:
-        If "img", use median, if "labels", use mode, if "coords", use max.
-    plot_result : bool
-        If True, plot the original and scaled images.
+        If "img", use block mean, if "labels", use mode, if "coords", use max.
 
     Returns:
     ----------
@@ -228,16 +225,9 @@ def scale_img(image, scaling_factor, upscale=False, input_type="img"):
         # Pad the image
         image = pad(image, (pad_top, pad_bot, pad_left, pad_right), input_type=input_type)
     
-    # IMAGES
-    img_strings = ('img', 'image', 'images') # Allow some flexibility in the input type string for images (but pass 'img' downstream)
-    if input_type in img_strings:
-        input_type = 'img'
-        if not use_gaussian_scaling:
-            # NEW (default): use block_reduce with mean
-            return scale_with_block_mean(image, scaling_factor)
-        else:
-            # OLD: by gaussian filter and striding
-            return scale_with_gaussian(image, scaling_factor, plot_blurred=plot_result)
+    # IMAGES: block-mean downscaling (strictly local — see scale_with_block_mean)
+    if input_type == 'img':
+        return scale_with_block_mean(image, scaling_factor)
 
     # For LABELS and COORDINATES, slice the last two dimensions
     slice_start = (0, 0) #((image.shape[-2] % scaling_factor) // 2,
@@ -276,13 +266,6 @@ def scale_img(image, scaling_factor, upscale=False, input_type="img"):
         if len(classes_before) != len(classes_after):
             warnings.warn(f"Classes have changed after downscaling from {classes_before} to {classes_after}.")
 
-        if plot_result:
-            from matplotlib import pyplot as plt
-            _, ax = plt.subplots(1, 2, figsize=(10, 5))
-            ax[0].imshow(image[0,...], cmap='gray')
-            ax[1].imshow(scaled_img[0,...], cmap='gray')
-            plt.show()
-        
         return scaled_img
 
     elif input_type == 'coords':
@@ -326,33 +309,6 @@ def scale_with_block_mean(image, scaling_factor):
         image = image[..., sh:H - (crop_h - sh), sw:W - (crop_w - sw)]
     block_shape = (1,) * (image.ndim - 2) + (scaling_factor, scaling_factor)
     return block_reduce(image, block_size=block_shape, func=np.mean)
-
-def scale_with_gaussian(image, scaling_factor, plot_blurred=False):
-    """Rescale image by Gaussian-blur + strided downsampling. The blur is intended to mitigate aliasing artifacts from the strided downsampling,
-    but it also causes some bleed across blocks, so features at a given position are influenced by a slightly larger area of the input image compared to block-mean downscaling.
-
-    Intended for use on images that have been padded to a multiple of `scaling_factor`.
-    But also works otherwise, in which case it centre-crops to a multiple of `scaling_factor` before block-reducing.
-    """
-    # Apply a small Gaussian blur to avoid aliasing
-    sigma = 0.4 * scaling_factor
-    sigma = [0] * (image.ndim - 2) + [sigma, sigma]  # Add zeros for batch and channel dimensions
-    blurred_img = gaussian_filter(image, sigma=sigma)  # assuming shape (..., H, W)
-    # Downsample by striding
-    H, W = image.shape[-2:]
-    start_h = scaling_factor // 2 # Move the start such that the image is centered (and with padding, the picked pixels align at the center of blocks)
-    start_w = scaling_factor // 2 # Move the start such that the image is centered (and with padding, the picked pixels align at the center of blocks)
-    scaled_img = blurred_img[..., start_h::scaling_factor, start_w::scaling_factor]
-
-    if plot_blurred:
-        from matplotlib import pyplot as plt
-        _, ax = plt.subplots(1, 3, figsize=(15, 5))
-        ax[0].imshow(image[0,0,...], cmap='gray')
-        ax[1].imshow(blurred_img[0,0,...], cmap='gray')
-        ax[2].imshow(scaled_img[0,0,...], cmap='gray')
-        plt.show()
-    
-    return scaled_img
 
 def fast_mode(arr, axis):
     """

--- a/src/napari_convpaint/utils.py
+++ b/src/napari_convpaint/utils.py
@@ -1193,8 +1193,16 @@ def normalize_image_imagenet(image):
             if (x.min() >= 0.0 and x.max() <= 1.0):
                 pass  # image compatible with [0,1]
             else:
-                warnings.warn(f"Image dtype is {image.dtype} and values are outside [0,1]. Not applying ImageNet normalization.")
-                return image  # return image as is
+                # Float image outside [0,1] (e.g. microscopy). Previously this was
+                # silently returned unnormalized, feeding out-of-distribution
+                # values to the ImageNet-pretrained network. Instead, robustly
+                # stretch to [0,1] with a 1-99 percentile before applying ImageNet
+                # stats. Measured to help segmentation (substantially for
+                # per-channel-varying float ranges) and never hurt vs raw.
+                lo, hi = np.percentile(x, 1), np.percentile(x, 99)
+                x = np.clip((x - lo) / (hi - lo + 1e-8), 0.0, 1.0)
+                warnings.warn(f"Image dtype is {image.dtype} with values outside [0,1]; "
+                              "applied a 1-99 percentile rescale to [0,1] before ImageNet normalization.")
         else:
             warnings.warn(f"Image dtype {image.dtype} is not supported for imagenet normalization. Not applying ImageNet normalization.")
             # mn, mx = x.min(), x.max()
@@ -1233,8 +1241,16 @@ def normalize_image_imagenet(image):
             if (x.min() >= 0.0 and x.max() <= 1.0):
                 pass  # image compatible with [0,1]
             else:
-                warnings.warn(f"Image dtype is {image.dtype} and values are outside [0,1]. Not applying ImageNet normalization.")
-                return image  # return image as is
+                # See the numpy path: robust 1-99 percentile stretch to [0,1]
+                # instead of silently leaving out-of-[0,1] float data unnormalized.
+                flat = x.flatten()
+                if flat.numel() > 16_000_000:  # torch.quantile caps input size
+                    flat = flat[:: (flat.numel() // 16_000_000) + 1]  # subsample for the percentile
+                lo = torch.quantile(flat, 0.01)
+                hi = torch.quantile(flat, 0.99)
+                x = torch.clamp((x - lo) / (hi - lo + 1e-8), 0.0, 1.0)
+                warnings.warn(f"Image dtype is {image.dtype} with values outside [0,1]; "
+                              "applied a 1-99 percentile rescale to [0,1] before ImageNet normalization.")
         else:
             warnings.warn(f"Image dtype {image.dtype} is not supported for imagenet normalization. Not applying ImageNet normalization.")
             return image  # return image as is

--- a/src/napari_convpaint/utils.py
+++ b/src/napari_convpaint/utils.py
@@ -380,15 +380,31 @@ def rescale_features(feature_img, target_shape, order=1):
 
     if feature_img.shape == output_shape:
         return feature_img
-    
+
+    # order>0 -> bilinear with align_corners=False, which matches skimage's
+    # half-pixel (pixel-centre) convention exactly, so there is no pixel shift.
+    # order=0 -> 'nearest-EXACT' (NOT plain 'nearest'): torch's default 'nearest'
+    # uses a floor/asymmetric grid that shifts by ~0.5 source-px vs skimage for
+    # non-integer scale ratios; 'nearest-exact' uses the same half-pixel nearest
+    # rule as skimage and is bit-identical for all ratios (verified).
+    int_mode = 'bilinear' if order > 0 else 'nearest-exact'
+    align_corners = False if order > 0 else None
+
     if isinstance(feature_img, torch.Tensor):
         # If the input is a PyTorch tensor, use the faster torch interpolation
-        int_mode = 'bilinear' if order > 0 else 'nearest'
-        align_corners = False if order > 0 else None
         return torch_interpolate(feature_img, size=output_shape[2:],
                                   mode=int_mode, align_corners=align_corners)
     else:
-        return skimage.transform.resize(feature_img, output_shape, order=order, mode='reflect', preserve_range=True)
+        # Route numpy arrays through torch interpolation too: skimage.transform.resize
+        # is dramatically slower here (per-channel CPU resize of many-channel feature
+        # stacks) — e.g. ~50x slower than torch when upsampling ViT patch features to
+        # full resolution, which made DINOv2/v3 feature-image and training extraction
+        # spend seconds in rescaling rather than in the network. For order=0 (nearest,
+        # the FE default) the result is identical to skimage; convert, interpolate,
+        # convert back to the original dtype.
+        t = torch.from_numpy(np.ascontiguousarray(feature_img)).float()
+        out = torch_interpolate(t, size=output_shape[2:], mode=int_mode, align_corners=align_corners)
+        return out.numpy().astype(feature_img.dtype, copy=False)
 
 def rescale_class_labels(label_img, output_shape):
     """
@@ -426,8 +442,24 @@ def rescale_outputs(output_img, output_shape, order=0):
     rescaled_output : np.ndarray
         Rescaled class probability or feature image.
     """
-    rescaled_output = skimage.transform.resize(output_img, output_shape, order=order, mode='reflect', preserve_range=True)
-    return rescaled_output
+    # Route through torch interpolation instead of skimage.transform.resize:
+    # this is the step that upsamples patched (e.g. DINOv2/v3) features from the
+    # patch grid to full resolution, and skimage is ~50x+ slower per-channel on
+    # CPU (measured ~13 s for a 384-channel ViT feature image where the network
+    # forward was 0.08 s). Only the last two dims are resized. order=0 uses
+    # 'nearest-exact' (not plain 'nearest') so it is bit-identical to skimage
+    # for all scale ratios — plain 'nearest' shifts by ~0.5 source-px on
+    # non-integer ratios; order>0 uses bilinear/align_corners=False, matching
+    # skimage's half-pixel convention (no shift). See rescale_features.
+    int_mode = 'bilinear' if order > 0 else 'nearest-exact'
+    align_corners = False if order > 0 else None
+    was_3d = output_img.ndim == 3  # [Z, H, W] -> add a channel dim for interpolate
+    arr = output_img[None] if was_3d else output_img
+    size = tuple(output_shape[-2:])
+    t = torch.from_numpy(np.ascontiguousarray(arr)).float()
+    out = torch_interpolate(t, size=size, mode=int_mode, align_corners=align_corners)
+    out = out.numpy().astype(output_img.dtype, copy=False)
+    return out[0] if was_3d else out
 
 
 ### CROPPING, PADDING, TILING & ANNOTATIONS EXTRACTION

--- a/src/napari_convpaint/utils.py
+++ b/src/napari_convpaint/utils.py
@@ -108,7 +108,11 @@ def guided_model_download(model_file: str, model_url: str, model_dir: str = None
         pass # Fall back to CLI progress if napari is not available
 
     if use_napari:
-        viewer.window._status_bar._toggle_activity_dock(True)
+        # Private napari API — best-effort only, never let a rename break downloads.
+        try:
+            viewer.window._status_bar._toggle_activity_dock(True)
+        except Exception:
+            pass
 
     try:
         with requests.get(model_url, stream=True) as r:
@@ -122,8 +126,12 @@ def guided_model_download(model_file: str, model_url: str, model_dir: str = None
                 pbr_ctx = napari_progress(total=num_chunks)
                 # No-op display() suppresses the activity-dock ETA label (which would
                 # otherwise overflow the row); the QProgressBar still advances via the
-                # 'value' event emitted by update().
-                pbr_ctx.display = lambda msg=None, pos=None: None
+                # 'value' event emitted by update(). Best-effort: relies on napari's
+                # tqdm-subclass internals.
+                try:
+                    pbr_ctx.display = lambda msg=None, pos=None: None
+                except Exception:
+                    pass
             else:
                 print(f"Downloading {model_file} ({total / 1e6:.2f} MB) from {model_url}...")
                 pbr_ctx = None
@@ -159,18 +167,21 @@ def guided_model_download(model_file: str, model_url: str, model_dir: str = None
         raise RuntimeError(f"Model download failed: {e}")
     finally:
         if use_napari:
-            viewer.window._status_bar._toggle_activity_dock(False)
+            try:
+                viewer.window._status_bar._toggle_activity_dock(False)
+            except Exception:
+                pass
 
     return model_path
 
 
 ### SCALING AND RESCALING
 
-def scale_img(image, scaling_factor, upscale=False, input_type="img", plot_result=False, use_gaussian_scaling=False):
+def scale_img(image, scaling_factor, upscale=False, input_type="img"):
     """
     Downscale an image by averaging over non-overlapping blocks of the specified size.
     OR Upscale by repeating the pixels.
-    
+
     Parameters:
     ----------
     image : np.ndarray

--- a/src/napari_convpaint/utils.py
+++ b/src/napari_convpaint/utils.py
@@ -406,6 +406,28 @@ def rescale_features(feature_img, target_shape, order=1):
         out = torch_interpolate(t, size=output_shape[2:], mode=int_mode, align_corners=align_corners)
         return out.numpy().astype(feature_img.dtype, copy=False)
 
+def resize_nearest(arr, out_hw):
+    """Fast nearest-neighbour resize of the last two (spatial) dims of ``arr``.
+
+    Bit-identical to ``skimage.transform.resize(arr, ..., order=0)`` for
+    upsampling (out_h >= in_h and out_w >= in_w), but done with an index gather
+    instead of scipy's per-element ``zoom_shift``, which is dramatically faster
+    for many-channel feature stacks (skimage is single-threaded per channel).
+
+    ``arr`` : np.ndarray with spatial dims last, e.g. [F, H, W] or [F, Z, H, W].
+    ``out_hw`` : (out_h, out_w).
+    """
+    in_h, in_w = arr.shape[-2], arr.shape[-1]
+    out_h, out_w = int(out_hw[-2]), int(out_hw[-1])
+    if (in_h, in_w) == (out_h, out_w):
+        return arr
+    # skimage order=0 maps output index o -> floor((o + 0.5) * in / out); this is
+    # exact for upsampling (verified against skimage for integer and non-integer
+    # ratios). Clip guards the borders.
+    row = np.clip(((np.arange(out_h) + 0.5) * in_h / out_h).astype(int), 0, in_h - 1)
+    col = np.clip(((np.arange(out_w) + 0.5) * in_w / out_w).astype(int), 0, in_w - 1)
+    return arr[..., row, :][..., :, col]
+
 def rescale_class_labels(label_img, output_shape):
     """
     Rescale a class label image to the specified output size.

--- a/src/napari_convpaint/utils.py
+++ b/src/napari_convpaint/utils.py
@@ -723,10 +723,20 @@ def tile_annot(img, annot, coords, padding, alignment=1, plot_tiles=False):
         # the image; since `_get_overall_paddings` now pads the whole image to a
         # multiple of `alignment`, clamping preserves the grid alignment too.
         if alignment > 1:
-            y_min = max(0, (y_min // alignment) * alignment)
-            x_min = max(0, (x_min // alignment) * alignment)
-            y_max = min(img_h, align_up(y_max, alignment))
-            x_max = min(img_w, align_up(x_max, alignment))
+            y_min = (y_min // alignment) * alignment
+            x_min = (x_min // alignment) * alignment
+            y_max = align_up(y_max, alignment)
+            x_max = align_up(x_max, alignment)
+        # Always clamp to the image bounds: the padding subtraction above can push
+        # y_min/x_min negative or y_max/x_max past the image, which would produce
+        # negative-start slices grabbing the wrong region. (Clamping to the image
+        # preserves grid alignment because the image is pre-padded to a multiple
+        # of `alignment`.) Previously this only ran for alignment > 1, leaving the
+        # alignment==1 case — gaussian/ilastik with padding — unguarded.
+        y_min = max(0, y_min)
+        x_min = max(0, x_min)
+        y_max = min(img_h, y_max)
+        x_max = min(img_w, x_max)
 
         if plot_tiles:
             # Draw the bounding box WITH PADDING on the image
@@ -817,12 +827,15 @@ def get_features_targets(features, annot):
     annot : np.ndarray
         Extracted targets from the input annotation. Shape is (num_pixels,).
     """
-    # Get the annotated pixels and targets
+    # Get the annotated pixels and targets.
+    # Index the feature axis (0) with the spatial mask directly instead of
+    # moveaxis-ing the whole [F, *spatial] stack to [*spatial, F] first — the
+    # moveaxis forces a full contiguous copy of the entire feature stack, while
+    # annotations are typically a small fraction of the pixels. features[:, mask]
+    # gathers only the annotated columns ([F, N]); the result is identical.
     mask = annot > 0
-    features = np.moveaxis(features, 0, -1) #move [z, h, w, features]
-    # Select only the pixels that are annotated, linearizing them
-    features = features[mask] # Get the features
-    annot = annot[mask] # Get the targets
+    features = features[:, mask].T  # [N, F], same rows/order as the old moveaxis path
+    annot = annot[mask]             # [N]
 
     return features, annot
 


### PR DESCRIPTION
## Summary

WIP... Autoreserach on performance/bugs using a small benchmark suite similar the quantifications in the paper.
For benchmark harness see [`performance-benchmarks`](https://github.com/hinderling/napari-convpaint/tree/performance-benchmarks/benchmarks) branch to keep this PR reviewable.) Some of the bugs captured seem relevant, a few cheap performance hacks; but feature caching is the biggest addition. Seems to work great in practice and noticeably speeds up workflows.

### Performance work

- **Content-addressed feature cache** with RAM budget, LRU eviction, and disk spillover — repeated annotate→predict iterations on the same slices reuse extracted features instead of recomputing them (biggest win for ViT-family extractors). Cache-first stack ordering avoids LRU thrash on predict-all.
- **Tiled / out-of-core prediction**: large images are predicted in aligned tiles (auto-enabled for local-context FEs), holding one tile's feature stack at a time; `segment_to_disk` streams the stitched result to a memmap/zarr.
- **Faster rescaling**: block-mean downscaling and torch-based feature rescaling (bit-identical `nearest-exact` for order 0), fast nearest path for cellpose.
- **Normalization fixes**: ImageNet normalization now handles float data outside [0, 1] (per-stack percentile stretch) and redundant re-normalization was removed.

### Correctness sweep

A multi-angle review of the branch surfaced 19 issues, all fixed in individually reviewable commits, plus 4 more found by a second sweep and in-depth testing of the fixes themselves. Highlights:

- **Tiling**: exact-multiple image sides produced an empty tile (crash for patch FEs); tile alignment and margins ignored `image_downsample` (visible seams); padding-0 FEs lost all tile overlap. Tile geometry now lives in `_tile_geometry`, pinned by tests that assert tiled output equals the whole-image pass.
- **Thread safety**: per-call shape bookkeeping raced across tile threads under the threaded dask cluster; it is now thread-local, and the model (incl. `Hookmodel`) is picklable again for dask submission.
- **Cache correctness**: FE instance state (e.g. JAFAR scalings, gaussian sigma) is now part of the cache key (stale-feature bug); payloads larger than the RAM cap spill straight to disk; CNN payloads no longer churn GBs through the disk tier; the widget no longer wipes the cache when it recreates its own layers.
- **Backward compatibility**: renamed FE models/aliases (`dinov2_vits14_reg`, `dino`, …) are remapped so saved models keep loading, and models trained under the old feature semantics (blur+stride downscaling, unstretched floats) trigger a retrain warning on load via a new `Param.feature_semantics` stamp.
- **Train/predict consistency**: single-plane prediction now normalizes ImageNet input with stack-scope statistics, matching training.
- Pre-existing `img_ids` misalignment in memory-mode training (silent training-table corruption) fixed.

### Tests

- New `test_bugfix_regressions.py` (17 tests) pins every fixed bug, including tiled == whole-image (with downsampling and with dask) and tile-coverage sweeps driven through the real geometry code.
- Full suite: **131 passed** (2 cellpose cases fail due to a broken local cellpose install, identically on `main`).