### PR TITLE
Widget: sync channel/norm radios with the model after setting a new FE

### DIFF
--- a/src/napari_convpaint/_tests/test_convpaint.py
+++ b/src/napari_convpaint/_tests/test_convpaint.py
@@ -795,3 +795,47 @@ def test_all_models_train_predict(make_napari_viewer, fe_name, image_type):
     seg = viewer.layers['segmentation'].data
     assert seg.shape == annot.shape, f"Segmentation shape {seg.shape} != annotations shape {annot.shape}"
     assert np.unique(seg).size > 1, "Segmentation is uniform — model produced no meaningful output"
+
+def test_set_fe_syncs_channel_and_norm_options(make_napari_viewer, capsys):
+    """Regression test: setting an FE that silently adjusts channel_mode must
+    refresh the channel-mode and normalization radios against the NEW model.
+
+    Repro without the fix: an RGB image puts the widget in 'rgb' mode; switching
+    to a 3D grayscale stack auto-maps 'rgb' to 'multi' (interpreted as one
+    multi-channel 2D image, so 'Norm. over stack' is disabled); setting an FE
+    whose default channel_mode is 'single' then rebuilds the model as 'single'
+    behind the radios' back. Clicking 'Single channel img' afterwards is
+    swallowed by the no-change guard in _on_channel_mode_changed (the model
+    already is 'single'), so the stack-normalization option can never be
+    re-enabled from the GUI."""
+    viewer = make_napari_viewer()
+    my_widget = ConvpaintWidget(viewer)
+    my_widget.ensure_init()
+
+    viewer.add_image((np.random.random((100, 100, 3)) * 255).astype(np.uint8),
+                     rgb=True, name='rgb_img')
+    viewer.add_image(np.random.random((10, 100, 100)), name='stack')
+
+    # RGB image -> widget goes to 'rgb' mode. (The changed-signal handler is
+    # QTimer-delayed, so call _on_select_layer directly in the test.)
+    my_widget.image_layer_selection_widget.value = viewer.layers['rgb_img']
+    my_widget._on_select_layer()
+    assert my_widget.cp_model.get_param('channel_mode') == 'rgb'
+
+    # 3D grayscale stack -> 'rgb' is auto-mapped to 'multi'; no stack dim in
+    # that interpretation, so stack normalization is (correctly) disabled
+    my_widget.image_layer_selection_widget.value = viewer.layers['stack']
+    my_widget._on_select_layer()
+    assert my_widget.cp_model.get_param('channel_mode') == 'multi'
+    assert not my_widget.radio_normalize_over_stack.isEnabled()
+
+    # Set an FE whose default channel_mode is 'single' (the Param default,
+    # so any FE without an explicit override works)
+    my_widget.qcombo_fe_type.setCurrentText('gaussian_features')
+    my_widget._on_set_fe_model()
+
+    # The radios must reflect the NEW model: single-channel selected, and
+    # stack normalization available again for the 3D stack
+    assert my_widget.cp_model.get_param('channel_mode') == 'single'
+    assert my_widget.radio_single_channel.isChecked()
+    assert my_widget.radio_normalize_over_stack.isEnabled()

--- a/src/napari_convpaint/convpaint_widget.py
+++ b/src/napari_convpaint/convpaint_widget.py
@@ -2432,8 +2432,6 @@ class ConvpaintWidget(QWidget):
             else: # If data is compatible, set the model's default multichannel setting; also assume this in case data_dims is None/invalid
                 adjusted_params.append('channel_mode')
                 new_param.channel_mode = fe_defaults.channel_mode
-                self._reset_radio_channel_mode_choices()
-                self._reset_radio_norm_choices() # Update norm options, since channel_mode changed
             # else: # If data is compatible, set the model's default RGB setting
             #     adjusted_params.append('rgb_img')
             #     if fe_defaults.rgb_img: # If the default model is RGB, set it
@@ -2475,6 +2473,9 @@ class ConvpaintWidget(QWidget):
 
         # Create a new model with the new FE
         self.cp_model = self._cpm_class(param=new_param)
+        # Sync the channel-mode and normalization radios with the new model's params
+        self._reset_radio_channel_mode_choices()
+        self._reset_radio_norm_choices()
         self._reset_device_options()
         self._reset_clf() # Call to take all actions needed after resetting the clf
         # Reset the features for continuous training


### PR DESCRIPTION
## Update (2nd commit)

Also fixes a related radio-sync bug: after an RGB image, selecting a 3D grayscale stack
carried the stale "rgb" mode over as "multi" (disabling stack normalization) instead of
the fresh-stack defaults ("single" + "norm. over stack"). `_get_data_dims()` now recovers
a stale "rgb" to "single" for 3D data, and the radio resets keep only an explicit "multi"
choice and no longer overwrite the "over stack" param while it is temporarily unavailable.

Because that changes the RGB→stack path the original test relied on, the test now
reproduces the same radio/model desync via an explicit user switch to "multi".
A second test covers the new RGB→stack behaviour. Both fail on main, pass here.

## Bug

`_on_set_fe_model` refreshes the channel-mode and normalization radio buttons **before** constructing the new `ConvpaintModel`, i.e. against the **old** model's params. When the FE's defaults silently adjust `channel_mode`, the new model and the radios end up permanently out of sync: a subsequent click on the already-active mode is swallowed by the no-change guard in `_on_channel_mode_changed`, so `_reset_radio_norm_choices()` never runs again and the normalization options stay stale.

## Repro (GUI)

1. Select an RGB image → widget goes to **rgb** mode.
2. Switch the image layer to a 3D grayscale stack → mode is auto-mapped to **multi** (`3D_multi` = one multi-channel 2D image, so *Norm. over stack* is correctly disabled).
3. Set any FE whose default channel mode is single (the `Param` default, so e.g. `dinov3_small-plus_jafar` or `gaussian_features`).

The rebuilt model is silently `single`, the radios still show the step-2 state, and **"Norm. over stack" can never be re-enabled from the GUI** — clicking *Single channel img* is a no-op because the model already is single.

## Fix

Move `_reset_radio_channel_mode_choices()` / `_reset_radio_norm_choices()` to after `self.cp_model = self._cpm_class(param=new_param)`, so the radios are synced against the model that actually exists (this also covers the fe-default `normalize` adjustment a few lines below).

## Test

`test_set_fe_syncs_channel_and_norm_options` walks the exact repro above; it fails on `main` and passes with the fix. Full widget test file (`-k "not all_models and not mps"`): 19 passed.